### PR TITLE
Bump version to v1.0.1

### DIFF
--- a/fastdds_python/CMakeLists.txt
+++ b/fastdds_python/CMakeLists.txt
@@ -24,7 +24,7 @@ if(POLICY CMP0086)
   cmake_policy(SET CMP0086 NEW)
 endif()
 
-project(fastdds_python VERSION 1.0.0)
+project(fastdds_python VERSION 1.0.1)
 
 ###############################################################################
 # Dependencies


### PR DESCRIPTION
This PR bumps the `fastdds_python` project version to v1.0.1