### PR TITLE
[14149] Fix ownership problem with listeners

### DIFF
--- a/fastdds_python/src/swig/fastdds.i
+++ b/fastdds_python/src/swig/fastdds.i
@@ -67,7 +67,6 @@ bool has_statistics()
   return false;
 #endif
 }
-
 %}
 
 bool has_statistics();

--- a/fastdds_python/src/swig/fastdds/dds/domain/DomainParticipant.i
+++ b/fastdds_python/src/swig/fastdds/dds/domain/DomainParticipant.i
@@ -16,8 +16,77 @@
 #include "fastdds/dds/domain/DomainParticipant.hpp"
 %}
 
+%extend eprosima::fastdds::dds::DomainParticipant
+{
+    ReturnCode_t set_listener(
+            DomainParticipantListener* listener)
+    {
+        eprosima::fastdds::dds::DomainParticipantListener* old_listener =
+            const_cast<eprosima::fastdds::dds::DomainParticipantListener*>(self->get_listener());
+
+        eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener);
+
+        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                Py_INCREF(director->swig_get_self());
+            }
+        }
+        if (nullptr != old_listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+            if (nullptr != director)
+            {
+                Py_DECREF(director->swig_get_self());
+            }
+        }
+        SWIG_PYTHON_THREAD_END_BLOCK;
+
+        return ret;
+    }
+
+    ReturnCode_t set_listener(
+            DomainParticipantListener* listener,
+            const StatusMask& mask)
+    {
+        eprosima::fastdds::dds::DomainParticipantListener* old_listener =
+            const_cast<eprosima::fastdds::dds::DomainParticipantListener*>(self->get_listener());
+
+        eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener, mask);
+
+        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                Py_INCREF(director->swig_get_self());
+            }
+        }
+        if (nullptr != old_listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+            if (nullptr != director)
+            {
+                Py_DECREF(director->swig_get_self());
+            }
+        }
+        SWIG_PYTHON_THREAD_END_BLOCK;
+
+        return ret;
+    }
+}
+
 %ignore eprosima::fastdds::dds::DomainParticipant::has_active_entities;
 %ignore eprosima::fastdds::dds::DomainParticipant::DomainParticipant;
 %ignore eprosima::fastdds::dds::DomainParticipant::~DomainParticipant;
+%ignore eprosima::fastdds::dds::DomainParticipant::set_listener;
 
 %include "fastdds/dds/domain/DomainParticipant.hpp"

--- a/fastdds_python/src/swig/fastdds/dds/domain/DomainParticipant.i
+++ b/fastdds_python/src/swig/fastdds/dds/domain/DomainParticipant.i
@@ -26,26 +26,31 @@
 
         eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener);
 
-        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-        if (nullptr != listener)
+        if ( (eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK == ret) && (listener != old_listener) )
         {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
+            SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+            if (nullptr != listener)
             {
-                Py_INCREF(director->swig_get_self());
-            }
-        }
-        if (nullptr != old_listener)
-        {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+                Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
-            {
-                Py_DECREF(director->swig_get_self());
+                if (nullptr != director)
+                {
+                    Py_INCREF(director->swig_get_self());
+                }
             }
+            if (nullptr != old_listener)
+            {
+                Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+                if (nullptr != director)
+                {
+                    Py_DECREF(director->swig_get_self());
+                }
+            }
+            SWIG_PYTHON_THREAD_END_BLOCK;
+
         }
-        SWIG_PYTHON_THREAD_END_BLOCK;
 
         return ret;
     }
@@ -59,26 +64,31 @@
 
         eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener, mask);
 
-        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-        if (nullptr != listener)
+        if ( (eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK == ret) && (listener != old_listener) )
         {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
+            SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+            if (nullptr != listener)
             {
-                Py_INCREF(director->swig_get_self());
+                Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+    
+                if (nullptr != director)
+                {
+                    Py_INCREF(director->swig_get_self());
+                }
             }
-        }
-        if (nullptr != old_listener)
-        {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+            if (nullptr != old_listener)
+            {
+                Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+    
+                if (nullptr != director)
+                {
+                    Py_DECREF(director->swig_get_self());
+                }
+            }
+            SWIG_PYTHON_THREAD_END_BLOCK;
 
-            if (nullptr != director)
-            {
-                Py_DECREF(director->swig_get_self());
-            }
         }
-        SWIG_PYTHON_THREAD_END_BLOCK;
 
         return ret;
     }

--- a/fastdds_python/src/swig/fastdds/dds/domain/DomainParticipant.i
+++ b/fastdds_python/src/swig/fastdds/dds/domain/DomainParticipant.i
@@ -82,11 +82,99 @@
 
         return ret;
     }
+
+    Publisher* create_publisher(
+            const PublisherQos& qos,
+            PublisherListener* listener = nullptr,
+            const StatusMask& mask = eprosima::fastdds::dds::StatusMask::all())
+    {
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+                Py_INCREF(director->swig_get_self());
+                SWIG_PYTHON_THREAD_END_BLOCK;
+            }
+        }
+
+        return self->create_publisher(qos, listener, mask);
+    }
+
+    ReturnCode_t delete_publisher(
+            const Publisher* publisher)
+    {
+        eprosima::fastdds::dds::PublisherListener* listener =
+            const_cast<eprosima::fastdds::dds::PublisherListener*>(publisher->get_listener());
+        eprosima::fastrtps::types::ReturnCode_t ret = self->delete_publisher(publisher);
+
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+                Py_DECREF(director->swig_get_self());
+                SWIG_PYTHON_THREAD_END_BLOCK;
+            }
+        }
+
+        return ret;
+    }
+
+    Subscriber* create_subscriber(
+            const SubscriberQos& qos,
+            SubscriberListener* listener = nullptr,
+            const StatusMask& mask = eprosima::fastdds::dds::StatusMask::all())
+    {
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+                Py_INCREF(director->swig_get_self());
+                SWIG_PYTHON_THREAD_END_BLOCK;
+            }
+        }
+
+        return self->create_subscriber(qos, listener, mask);
+    }
+
+    ReturnCode_t delete_subscriber(
+            const Subscriber* subscriber)
+    {
+        eprosima::fastdds::dds::SubscriberListener* listener =
+            const_cast<eprosima::fastdds::dds::SubscriberListener*>(subscriber->get_listener());
+        eprosima::fastrtps::types::ReturnCode_t ret = self->delete_subscriber(subscriber);
+
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+                Py_DECREF(director->swig_get_self());
+                SWIG_PYTHON_THREAD_END_BLOCK;
+            }
+        }
+
+        return ret;
+    }
 }
 
 %ignore eprosima::fastdds::dds::DomainParticipant::has_active_entities;
 %ignore eprosima::fastdds::dds::DomainParticipant::DomainParticipant;
 %ignore eprosima::fastdds::dds::DomainParticipant::~DomainParticipant;
 %ignore eprosima::fastdds::dds::DomainParticipant::set_listener;
+%ignore eprosima::fastdds::dds::DomainParticipant::create_publisher;
+%ignore eprosima::fastdds::dds::DomainParticipant::create_subscriber;
+%ignore eprosima::fastdds::dds::DomainParticipant::delete_publisher;
+%ignore eprosima::fastdds::dds::DomainParticipant::delete_subscriber;
 
 %include "fastdds/dds/domain/DomainParticipant.hpp"

--- a/fastdds_python/src/swig/fastdds/dds/domain/DomainParticipantFactory.i
+++ b/fastdds_python/src/swig/fastdds/dds/domain/DomainParticipantFactory.i
@@ -16,4 +16,58 @@
 #include "fastdds/dds/domain/DomainParticipantFactory.hpp"
 %}
 
+/*
+%extend eprosima::fastdds::dds::DomainParticipantFactory
+{
+}
+*/
+%extend eprosima::fastdds::dds::DomainParticipantFactory
+{
+    DomainParticipant* create_participant(
+            DomainId_t domain_id,
+            const DomainParticipantQos& qos,
+            DomainParticipantListener* listener = nullptr,
+            const StatusMask& mask = eprosima::fastdds::dds::StatusMask::all())
+    {
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+                Py_INCREF(director->swig_get_self());
+                SWIG_PYTHON_THREAD_END_BLOCK;
+            }
+        }
+
+        return self->create_participant(domain_id, qos, listener, mask);
+    }
+
+    ReturnCode_t delete_participant(
+            DomainParticipant* part)
+    {
+        eprosima::fastdds::dds::DomainParticipantListener* listener =
+            const_cast<eprosima::fastdds::dds::DomainParticipantListener*>(part->get_listener());
+        eprosima::fastrtps::types::ReturnCode_t ret = self->delete_participant(part);
+
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+                Py_DECREF(director->swig_get_self());
+                SWIG_PYTHON_THREAD_END_BLOCK;
+            }
+        }
+
+        return ret;
+    }
+}
+
+%ignore eprosima::fastdds::dds::DomainParticipantFactory::create_participant;
+%ignore eprosima::fastdds::dds::DomainParticipantFactory::delete_participant;
+
 %include "fastdds/dds/domain/DomainParticipantFactory.hpp"

--- a/fastdds_python/src/swig/fastdds/dds/publisher/DataWriter.i
+++ b/fastdds_python/src/swig/fastdds/dds/publisher/DataWriter.i
@@ -43,7 +43,74 @@
         eprosima::fastrtps::types::ReturnCode_t ret = self->clear_history(removed);
         return ret;
     }
+
+    ReturnCode_t set_listener(
+            DataWriterListener* listener)
+    {
+        eprosima::fastdds::dds::DataWriterListener* old_listener =
+            const_cast<eprosima::fastdds::dds::DataWriterListener*>(self->get_listener());
+
+        eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener);
+
+        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                Py_INCREF(director->swig_get_self());
+            }
+        }
+        if (nullptr != old_listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+            if (nullptr != director)
+            {
+                Py_DECREF(director->swig_get_self());
+            }
+        }
+        SWIG_PYTHON_THREAD_END_BLOCK;
+
+        return ret;
+    }
+
+    ReturnCode_t set_listener(
+            DataWriterListener* listener,
+            const StatusMask& mask)
+    {
+        eprosima::fastdds::dds::DataWriterListener* old_listener =
+            const_cast<eprosima::fastdds::dds::DataWriterListener*>(self->get_listener());
+
+        eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener, mask);
+
+        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                Py_INCREF(director->swig_get_self());
+            }
+        }
+        if (nullptr != old_listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+            if (nullptr != director)
+            {
+                Py_DECREF(director->swig_get_self());
+            }
+        }
+        SWIG_PYTHON_THREAD_END_BLOCK;
+
+        return ret;
+    }
 }
+
+%ignore eprosima::fastdds::dds::DataWriter::set_listener;
 %ignore eprosima::fastdds::dds::DataWriter::clear_history(size_t*);
 
 // Template for std::vector<DataWriter*>

--- a/fastdds_python/src/swig/fastdds/dds/publisher/DataWriter.i
+++ b/fastdds_python/src/swig/fastdds/dds/publisher/DataWriter.i
@@ -52,26 +52,31 @@
 
         eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener);
 
-        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-        if (nullptr != listener)
+        if ( (eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK == ret) && (listener != old_listener) )
         {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
+            SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+            if (nullptr != listener)
             {
-                Py_INCREF(director->swig_get_self());
-            }
-        }
-        if (nullptr != old_listener)
-        {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+                Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
-            {
-                Py_DECREF(director->swig_get_self());
+                if (nullptr != director)
+                {
+                    Py_INCREF(director->swig_get_self());
+                }
             }
+            if (nullptr != old_listener)
+            {
+                Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+                if (nullptr != director)
+                {
+                    Py_DECREF(director->swig_get_self());
+                }
+            }
+            SWIG_PYTHON_THREAD_END_BLOCK;
+
         }
-        SWIG_PYTHON_THREAD_END_BLOCK;
 
         return ret;
     }
@@ -85,26 +90,31 @@
 
         eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener, mask);
 
-        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-        if (nullptr != listener)
+        if ( (eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK == ret) && (listener != old_listener) )
         {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
+            SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+            if (nullptr != listener)
             {
-                Py_INCREF(director->swig_get_self());
-            }
-        }
-        if (nullptr != old_listener)
-        {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+                Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
-            {
-                Py_DECREF(director->swig_get_self());
+                if (nullptr != director)
+                {
+                    Py_INCREF(director->swig_get_self());
+                }
             }
+            if (nullptr != old_listener)
+            {
+                Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+                if (nullptr != director)
+                {
+                    Py_DECREF(director->swig_get_self());
+                }
+            }
+            SWIG_PYTHON_THREAD_END_BLOCK;
+
         }
-        SWIG_PYTHON_THREAD_END_BLOCK;
 
         return ret;
     }

--- a/fastdds_python/src/swig/fastdds/dds/publisher/Publisher.i
+++ b/fastdds_python/src/swig/fastdds/dds/publisher/Publisher.i
@@ -82,10 +82,55 @@
 
         return ret;
     }
+
+    DataWriter* create_datawriter(
+            Topic* topic,
+            const DataWriterQos& writer_qos,
+            DataWriterListener* listener = nullptr,
+            const StatusMask& mask = eprosima::fastdds::dds::StatusMask::all())
+    {
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+                Py_INCREF(director->swig_get_self());
+                SWIG_PYTHON_THREAD_END_BLOCK;
+            }
+        }
+
+        return self->create_datawriter(topic, writer_qos, listener, mask);
+    }
+
+    ReturnCode_t delete_datawriter(
+            const DataWriter* writer)
+    {
+        eprosima::fastdds::dds::DataWriterListener* listener =
+            const_cast<eprosima::fastdds::dds::DataWriterListener*>(writer->get_listener());
+        eprosima::fastrtps::types::ReturnCode_t ret = self->delete_datawriter(writer);
+
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+                Py_DECREF(director->swig_get_self());
+                SWIG_PYTHON_THREAD_END_BLOCK;
+            }
+        }
+
+        return ret;
+    }
 }
 
 %ignore eprosima::fastdds::dds::Publisher::Publisher;
 %ignore eprosima::fastdds::dds::Publisher::~Publisher;
 %ignore eprosima::fastdds::dds::Publisher::set_listener;
+%ignore eprosima::fastdds::dds::Publisher::create_datawriter;
+%ignore eprosima::fastdds::dds::Publisher::delete_datawriter;
 
 %include "fastdds/dds/publisher/Publisher.hpp"

--- a/fastdds_python/src/swig/fastdds/dds/publisher/Publisher.i
+++ b/fastdds_python/src/swig/fastdds/dds/publisher/Publisher.i
@@ -26,26 +26,31 @@
 
         eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener);
 
-        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-        if (nullptr != listener)
+        if ( (eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK == ret) && (listener != old_listener) )
         {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
+            SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+            if (nullptr != listener)
             {
-                Py_INCREF(director->swig_get_self());
-            }
-        }
-        if (nullptr != old_listener)
-        {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+                Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
-            {
-                Py_DECREF(director->swig_get_self());
+                if (nullptr != director)
+                {
+                    Py_INCREF(director->swig_get_self());
+                }
             }
+            if (nullptr != old_listener)
+            {
+                Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+                if (nullptr != director)
+                {
+                    Py_DECREF(director->swig_get_self());
+                }
+            }
+            SWIG_PYTHON_THREAD_END_BLOCK;
+
         }
-        SWIG_PYTHON_THREAD_END_BLOCK;
 
         return ret;
     }
@@ -59,26 +64,31 @@
 
         eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener, mask);
 
-        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-        if (nullptr != listener)
+        if ( (eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK == ret) && (listener != old_listener) )
         {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
+            SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+            if (nullptr != listener)
             {
-                Py_INCREF(director->swig_get_self());
-            }
-        }
-        if (nullptr != old_listener)
-        {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+                Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
-            {
-                Py_DECREF(director->swig_get_self());
+                if (nullptr != director)
+                {
+                    Py_INCREF(director->swig_get_self());
+                }
             }
+            if (nullptr != old_listener)
+            {
+                Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+                if (nullptr != director)
+                {
+                    Py_DECREF(director->swig_get_self());
+                }
+            }
+            SWIG_PYTHON_THREAD_END_BLOCK;
+
         }
-        SWIG_PYTHON_THREAD_END_BLOCK;
 
         return ret;
     }

--- a/fastdds_python/src/swig/fastdds/dds/publisher/Publisher.i
+++ b/fastdds_python/src/swig/fastdds/dds/publisher/Publisher.i
@@ -16,7 +16,76 @@
 #include "fastdds/dds/publisher/Publisher.hpp"
 %}
 
+%extend eprosima::fastdds::dds::Publisher
+{
+    ReturnCode_t set_listener(
+            PublisherListener* listener)
+    {
+        eprosima::fastdds::dds::PublisherListener* old_listener =
+            const_cast<eprosima::fastdds::dds::PublisherListener*>(self->get_listener());
+
+        eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener);
+
+        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                Py_INCREF(director->swig_get_self());
+            }
+        }
+        if (nullptr != old_listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+            if (nullptr != director)
+            {
+                Py_DECREF(director->swig_get_self());
+            }
+        }
+        SWIG_PYTHON_THREAD_END_BLOCK;
+
+        return ret;
+    }
+
+    ReturnCode_t set_listener(
+            PublisherListener* listener,
+            const StatusMask& mask)
+    {
+        eprosima::fastdds::dds::PublisherListener* old_listener =
+            const_cast<eprosima::fastdds::dds::PublisherListener*>(self->get_listener());
+
+        eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener, mask);
+
+        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                Py_INCREF(director->swig_get_self());
+            }
+        }
+        if (nullptr != old_listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+            if (nullptr != director)
+            {
+                Py_DECREF(director->swig_get_self());
+            }
+        }
+        SWIG_PYTHON_THREAD_END_BLOCK;
+
+        return ret;
+    }
+}
+
 %ignore eprosima::fastdds::dds::Publisher::Publisher;
 %ignore eprosima::fastdds::dds::Publisher::~Publisher;
+%ignore eprosima::fastdds::dds::Publisher::set_listener;
 
 %include "fastdds/dds/publisher/Publisher.hpp"

--- a/fastdds_python/src/swig/fastdds/dds/subscriber/DataReader.i
+++ b/fastdds_python/src/swig/fastdds/dds/subscriber/DataReader.i
@@ -43,26 +43,31 @@
 
         eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener);
 
-        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-        if (nullptr != listener)
+        if ( (eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK == ret) && (listener != old_listener) )
         {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
+            SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+            if (nullptr != listener)
             {
-                Py_INCREF(director->swig_get_self());
-            }
-        }
-        if (nullptr != old_listener)
-        {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+                Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
-            {
-                Py_DECREF(director->swig_get_self());
+                if (nullptr != director)
+                {
+                    Py_INCREF(director->swig_get_self());
+                }
             }
+            if (nullptr != old_listener)
+            {
+                Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+                if (nullptr != director)
+                {
+                    Py_DECREF(director->swig_get_self());
+                }
+            }
+            SWIG_PYTHON_THREAD_END_BLOCK;
+
         }
-        SWIG_PYTHON_THREAD_END_BLOCK;
 
         return ret;
     }
@@ -76,26 +81,31 @@
 
         eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener, mask);
 
-        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-        if (nullptr != listener)
+        if ( (eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK == ret) && (listener != old_listener) )
         {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
+            SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+            if (nullptr != listener)
             {
-                Py_INCREF(director->swig_get_self());
+                Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+    
+                if (nullptr != director)
+                {
+                    Py_INCREF(director->swig_get_self());
+                }
             }
-        }
-        if (nullptr != old_listener)
-        {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+            if (nullptr != old_listener)
+            {
+                Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+    
+                if (nullptr != director)
+                {
+                    Py_DECREF(director->swig_get_self());
+                }
+            }
+            SWIG_PYTHON_THREAD_END_BLOCK;
 
-            if (nullptr != director)
-            {
-                Py_DECREF(director->swig_get_self());
-            }
         }
-        SWIG_PYTHON_THREAD_END_BLOCK;
 
         return ret;
     }

--- a/fastdds_python/src/swig/fastdds/dds/subscriber/DataReader.i
+++ b/fastdds_python/src/swig/fastdds/dds/subscriber/DataReader.i
@@ -32,4 +32,75 @@
     }
 }
 
+
+%extend eprosima::fastdds::dds::DataReader
+{
+    ReturnCode_t set_listener(
+            DataReaderListener* listener)
+    {
+        eprosima::fastdds::dds::DataReaderListener* old_listener =
+            const_cast<eprosima::fastdds::dds::DataReaderListener*>(self->get_listener());
+
+        eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener);
+
+        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                Py_INCREF(director->swig_get_self());
+            }
+        }
+        if (nullptr != old_listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+            if (nullptr != director)
+            {
+                Py_DECREF(director->swig_get_self());
+            }
+        }
+        SWIG_PYTHON_THREAD_END_BLOCK;
+
+        return ret;
+    }
+
+    ReturnCode_t set_listener(
+            DataReaderListener* listener,
+            const StatusMask& mask)
+    {
+        eprosima::fastdds::dds::DataReaderListener* old_listener =
+            const_cast<eprosima::fastdds::dds::DataReaderListener*>(self->get_listener());
+
+        eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener, mask);
+
+        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                Py_INCREF(director->swig_get_self());
+            }
+        }
+        if (nullptr != old_listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+            if (nullptr != director)
+            {
+                Py_DECREF(director->swig_get_self());
+            }
+        }
+        SWIG_PYTHON_THREAD_END_BLOCK;
+
+        return ret;
+    }
+}
+
+%ignore eprosima::fastdds::dds::DataReader::set_listener;
+
 %include "fastdds/dds/subscriber/DataReader.hpp"

--- a/fastdds_python/src/swig/fastdds/dds/subscriber/Subscriber.i
+++ b/fastdds_python/src/swig/fastdds/dds/subscriber/Subscriber.i
@@ -26,26 +26,31 @@
 
         eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener);
 
-        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-        if (nullptr != listener)
+        if ( (eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK == ret) && (listener != old_listener) )
         {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
+            SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+            if (nullptr != listener)
             {
-                Py_INCREF(director->swig_get_self());
-            }
-        }
-        if (nullptr != old_listener)
-        {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+                Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
-            {
-                Py_DECREF(director->swig_get_self());
+                if (nullptr != director)
+                {
+                    Py_INCREF(director->swig_get_self());
+                }
             }
+            if (nullptr != old_listener)
+            {
+                Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+                if (nullptr != director)
+                {
+                    Py_DECREF(director->swig_get_self());
+                }
+            }
+            SWIG_PYTHON_THREAD_END_BLOCK;
+
         }
-        SWIG_PYTHON_THREAD_END_BLOCK;
 
         return ret;
     }
@@ -59,26 +64,31 @@
 
         eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener, mask);
 
-        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-        if (nullptr != listener)
+        if ( (eprosima::fastrtps::types::ReturnCode_t::RETCODE_OK == ret) && (listener != old_listener) )
         {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
+            SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+            if (nullptr != listener)
             {
-                Py_INCREF(director->swig_get_self());
-            }
-        }
-        if (nullptr != old_listener)
-        {
-            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+                Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
 
-            if (nullptr != director)
-            {
-                Py_DECREF(director->swig_get_self());
+                if (nullptr != director)
+                {
+                    Py_INCREF(director->swig_get_self());
+                }
             }
+            if (nullptr != old_listener)
+            {
+                Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+                if (nullptr != director)
+                {
+                    Py_DECREF(director->swig_get_self());
+                }
+            }
+            SWIG_PYTHON_THREAD_END_BLOCK;
+
         }
-        SWIG_PYTHON_THREAD_END_BLOCK;
 
         return ret;
     }

--- a/fastdds_python/src/swig/fastdds/dds/subscriber/Subscriber.i
+++ b/fastdds_python/src/swig/fastdds/dds/subscriber/Subscriber.i
@@ -82,10 +82,55 @@
 
         return ret;
     }
+
+    DataReader* create_datareader(
+            TopicDescription* topic,
+            const DataReaderQos& reader_qos,
+            DataReaderListener* listener = nullptr,
+            const StatusMask& mask = eprosima::fastdds::dds::StatusMask::all())
+    {
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+                Py_INCREF(director->swig_get_self());
+                SWIG_PYTHON_THREAD_END_BLOCK;
+            }
+        }
+
+        return self->create_datareader(topic, reader_qos, listener, mask);
+    }
+
+    ReturnCode_t delete_datareader(
+            const DataReader* reader)
+    {
+        eprosima::fastdds::dds::DataReaderListener* listener =
+            const_cast<eprosima::fastdds::dds::DataReaderListener*>(reader->get_listener());
+        eprosima::fastrtps::types::ReturnCode_t ret = self->delete_datareader(reader);
+
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+                Py_DECREF(director->swig_get_self());
+                SWIG_PYTHON_THREAD_END_BLOCK;
+            }
+        }
+
+        return ret;
+    }
 }
 
 %ignore eprosima::fastdds::dds::Subscriber::Subscriber;
 %ignore eprosima::fastdds::dds::Subscriber::~Subscriber;
 %ignore eprosima::fastdds::dds::Subscriber::set_listener;
+%ignore eprosima::fastdds::dds::Subscriber::create_datareader;
+%ignore eprosima::fastdds::dds::Subscriber::delete_datareader;
 
 %include "fastdds/dds/subscriber/Subscriber.hpp"

--- a/fastdds_python/src/swig/fastdds/dds/subscriber/Subscriber.i
+++ b/fastdds_python/src/swig/fastdds/dds/subscriber/Subscriber.i
@@ -16,7 +16,76 @@
 #include "fastdds/dds/subscriber/Subscriber.hpp"
 %}
 
+%extend eprosima::fastdds::dds::Subscriber
+{
+    ReturnCode_t set_listener(
+            SubscriberListener* listener)
+    {
+        eprosima::fastdds::dds::SubscriberListener* old_listener =
+            const_cast<eprosima::fastdds::dds::SubscriberListener*>(self->get_listener());
+
+        eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener);
+
+        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                Py_INCREF(director->swig_get_self());
+            }
+        }
+        if (nullptr != old_listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+            if (nullptr != director)
+            {
+                Py_DECREF(director->swig_get_self());
+            }
+        }
+        SWIG_PYTHON_THREAD_END_BLOCK;
+
+        return ret;
+    }
+
+    ReturnCode_t set_listener(
+            SubscriberListener* listener,
+            const StatusMask& mask)
+    {
+        eprosima::fastdds::dds::SubscriberListener* old_listener =
+            const_cast<eprosima::fastdds::dds::SubscriberListener*>(self->get_listener());
+
+        eprosima::fastrtps::types::ReturnCode_t ret = self->set_listener(listener, mask);
+
+        SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                Py_INCREF(director->swig_get_self());
+            }
+        }
+        if (nullptr != old_listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
+
+            if (nullptr != director)
+            {
+                Py_DECREF(director->swig_get_self());
+            }
+        }
+        SWIG_PYTHON_THREAD_END_BLOCK;
+
+        return ret;
+    }
+}
+
 %ignore eprosima::fastdds::dds::Subscriber::Subscriber;
 %ignore eprosima::fastdds::dds::Subscriber::~Subscriber;
+%ignore eprosima::fastdds::dds::Subscriber::set_listener;
 
 %include "fastdds/dds/subscriber/Subscriber.hpp"

--- a/fastdds_python/test/CMakeLists.txt
+++ b/fastdds_python/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Compile types
 add_subdirectory(types)
 
-add_test(NAME api_tests COMMAND ${Python3_EXECUTABLE} -m pytest WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/api)
+add_test(NAME api_tests COMMAND ${Python3_EXECUTABLE} -m pytest -vrP test_domainparticipant.py WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/api)

--- a/fastdds_python/test/CMakeLists.txt
+++ b/fastdds_python/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Compile types
 add_subdirectory(types)
 
-add_test(NAME api_tests COMMAND ${Python3_EXECUTABLE} -m pytest -vrP test_domainparticipant.py WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/api)
+add_test(NAME api_tests COMMAND ${Python3_EXECUTABLE} -m pytest -vrP WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/api)

--- a/fastdds_python/test/api/test_datareader.py
+++ b/fastdds_python/test/api/test_datareader.py
@@ -791,13 +791,13 @@ def test_listener_ownership(participant, writer_participant, topic,
     datawriter = publisher.create_datawriter(
                 writer_topic, fastdds.DATAWRITER_QOS_DEFAULT)
     time.sleep(1)
+    factory = fastdds.DomainParticipantFactory.get_instance()
     assert(fastdds.ReturnCode_t.RETCODE_OK ==
            publisher.delete_datawriter(datawriter))
     assert(fastdds.ReturnCode_t.RETCODE_OK ==
            writer_participant.delete_topic(writer_topic))
     assert(fastdds.ReturnCode_t.RETCODE_OK ==
            writer_participant.delete_publisher(publisher))
-    factory = fastdds.DomainParticipantFactory.get_instance()
     assert(fastdds.ReturnCode_t.RETCODE_OK ==
            factory.delete_participant(writer_participant))
     assert(fastdds.ReturnCode_t.RETCODE_OK ==
@@ -806,6 +806,5 @@ def test_listener_ownership(participant, writer_participant, topic,
            participant.delete_topic(topic))
     assert(fastdds.ReturnCode_t.RETCODE_OK ==
            participant.delete_subscriber(subscriber))
-    factory = fastdds.DomainParticipantFactory.get_instance()
     assert(fastdds.ReturnCode_t.RETCODE_OK ==
            factory.delete_participant(participant))

--- a/fastdds_python/test/api/test_datawriter.py
+++ b/fastdds_python/test/api/test_datawriter.py
@@ -96,24 +96,6 @@ def subscriber(reader_participant):
     return reader_participant.create_subscriber(fastdds.SUBSCRIBER_QOS_DEFAULT)
 
 
-@pytest.fixture
-def datareader(reader_participant, reader_topic, subscriber):
-    datareader = subscriber.create_datareader(
-            reader_topic, fastdds.DATAREADER_QOS_DEFAULT)
-
-    yield datareader
-
-    assert(fastdds.ReturnCode_t.RETCODE_OK ==
-           subscriber.delete_datareader(datareader))
-    assert(fastdds.ReturnCode_t.RETCODE_OK ==
-           reader_participant.delete_topic(reader_topic))
-    assert(fastdds.ReturnCode_t.RETCODE_OK ==
-           reader_participant.delete_subscriber(subscriber))
-    factory = fastdds.DomainParticipantFactory.get_instance()
-    assert(fastdds.ReturnCode_t.RETCODE_OK ==
-           factory.delete_participant(reader_participant))
-
-
 def test_assert_liveliness(manual_liveliness_datawriter_qos, datawriter):
     """
     This test checks:

--- a/fastdds_python/test/api/test_publisher.py
+++ b/fastdds_python/test/api/test_publisher.py
@@ -295,7 +295,6 @@ def test_get_set_listener(publisher):
            publisher.set_listener(listener))
     assert(publisher.get_listener() == listener)
     assert(fastdds.StatusMask.all() == publisher.get_status_mask())
-    publisher.set_listener(None)
 
     def test(status_mask_1, status_mask_2):
         """
@@ -307,14 +306,12 @@ def test_get_set_listener(publisher):
                publisher.set_listener(listener, status_mask_1))
         assert(publisher.get_listener() == listener)
         assert(status_mask_1 == publisher.get_status_mask())
-        publisher.set_listener(None)
         listener = PublisherListener()
         assert(listener is not None)
         assert(fastdds.ReturnCode_t.RETCODE_OK ==
                publisher.set_listener(listener, status_mask_2))
         assert(publisher.get_listener() == listener)
         assert(status_mask_2 == publisher.get_status_mask())
-        publisher.set_listener(None)
 
     # Overload 2: Different status masks
     test(fastdds.StatusMask.all(), fastdds.StatusMask_all())

--- a/fastdds_python/test/api/test_subscriber.py
+++ b/fastdds_python/test/api/test_subscriber.py
@@ -290,7 +290,6 @@ def test_get_set_listener(subscriber):
            subscriber.set_listener(listener))
     assert(subscriber.get_listener() == listener)
     assert(fastdds.StatusMask.all() == subscriber.get_status_mask())
-    subscriber.set_listener(None)
 
     def test(status_mask_1, status_mask_2):
         """
@@ -302,14 +301,12 @@ def test_get_set_listener(subscriber):
                subscriber.set_listener(listener, status_mask_1))
         assert(subscriber.get_listener() == listener)
         assert(status_mask_1 == subscriber.get_status_mask())
-        subscriber.set_listener(None)
         listener = SubscriberListener()
         assert(listener is not None)
         assert(fastdds.ReturnCode_t.RETCODE_OK ==
                subscriber.set_listener(listener, status_mask_2))
         assert(subscriber.get_listener() == listener)
         assert(status_mask_2 == subscriber.get_status_mask())
-        subscriber.set_listener(None)
 
     # Overload 2: Different status masks
     test(fastdds.StatusMask.all(), fastdds.StatusMask_all())

--- a/fastdds_python/test/api/test_subscriber.py
+++ b/fastdds_python/test/api/test_subscriber.py
@@ -1,6 +1,7 @@
 import fastdds
 import pytest
 import test_complete
+import time
 
 
 class SubscriberListener (fastdds.SubscriberListener):
@@ -54,6 +55,28 @@ def topic(participant):
     return participant.create_topic(
             "Complete", test_type.get_type_name(), fastdds.TOPIC_QOS_DEFAULT)
 
+@pytest.fixture
+def test_type():
+    return fastdds.TypeSupport(
+            test_complete.CompleteTestTypePubSubType())
+
+@pytest.fixture
+def writer_participant():
+    factory = fastdds.DomainParticipantFactory.get_instance()
+    return factory.create_participant(
+            0, fastdds.PARTICIPANT_QOS_DEFAULT)
+
+
+@pytest.fixture
+def writer_topic(writer_participant, test_type):
+    writer_participant.register_type(test_type, test_type.get_type_name())
+    return writer_participant.create_topic(
+            "Complete", test_type.get_type_name(), fastdds.TOPIC_QOS_DEFAULT)
+
+
+@pytest.fixture
+def publisher(writer_participant):
+    return writer_participant.create_publisher(fastdds.PUBLISHER_QOS_DEFAULT)
 
 def test_access(subscriber):
     """
@@ -384,3 +407,36 @@ def test_lookup_datareader(topic, subscriber):
 
     assert(fastdds.ReturnCode_t.RETCODE_OK ==
            subscriber.delete_datareader(datareader))
+
+
+def test_listener_ownership(participant, writer_participant, topic,
+                            writer_topic, publisher):
+
+    def create_subcriber():
+        listener = SubscriberListener()
+        return participant.create_subscriber(
+                fastdds.SUBSCRIBER_QOS_DEFAULT, listener)
+
+    subscriber = create_subcriber()
+    datareader = subscriber.create_datareader(
+                topic, fastdds.DATAREADER_QOS_DEFAULT)
+    datawriter = publisher.create_datawriter(
+                writer_topic, fastdds.DATAWRITER_QOS_DEFAULT)
+    time.sleep(1)
+    factory = fastdds.DomainParticipantFactory.get_instance()
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           publisher.delete_datawriter(datawriter))
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           writer_participant.delete_topic(writer_topic))
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           writer_participant.delete_publisher(publisher))
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           factory.delete_participant(writer_participant))
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           subscriber.delete_datareader(datareader))
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           participant.delete_topic(topic))
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           participant.delete_subscriber(subscriber))
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           factory.delete_participant(participant))


### PR DESCRIPTION
Due to listeners are objects created directly on Python. Python manages them and it could delete them while they are been used internally by Fast DDS.
This PR fixes this increasing the internal Python references counter when the listeners are set to be used by Fast DDS, and decreasing them when Fast DDS leaves to use them.

This PR depends on be rebased over:

* #19 