### PR TITLE
[14513] Tests for DataWriter.get_key_value

### DIFF
--- a/fastdds_python/test/api/test_datawriter.py
+++ b/fastdds_python/test/api/test_datawriter.py
@@ -174,12 +174,55 @@ def test_get_key_value(test_keyed_type, datawriter):
     This test checks:
     - DataWriter::get_key_value
     """
+    # Prepare test variables
     sample = test_complete.KeyedCompleteTestType()
-    ih = fastdds.InstanceHandle_t()
-    assert(fastdds.ReturnCode_t.RETCODE_UNSUPPORTED ==
-           datawriter.get_key_value(sample, ih))
-    assert(fastdds.c_InstanceHandle_Unknown == ih)
-
+    sample.id(1)
+    ih = datawriter.register_instance(sample)
+    wrong_ih = fastdds.InstanceHandle_t()
+    wrong_ih.value[0] = 27;
+    assert(fastdds.c_InstanceHandle_Unknown != ih)
+    assert(wrong_ih != ih)
+    
+    # Check wrong handles
+    test_sample = test_complete.KeyedCompleteTestType()
+    assert(fastdds.ReturnCode_t.RETCODE_BAD_PARAMETER ==
+           datawriter.get_key_value(test_sample, fastdds.c_InstanceHandle_Unknown))
+    assert(fastdds.ReturnCode_t.RETCODE_BAD_PARAMETER ==
+           datawriter.get_key_value(test_sample, wrong_ih))
+    
+    # Check wrong sample
+    assert(fastdds.ReturnCode_t.RETCODE_BAD_PARAMETER ==
+           datawriter.get_key_value(None, ih))
+    
+    # Check correct case
+    test_sample = test_complete.KeyedCompleteTestType()
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           datawriter.get_key_value(test_sample, ih))
+    assert(test_sample.id() == sample.id());
+    
+    # Calling get_key_value on an unregistered instance should fail
+    test_sample = test_complete.KeyedCompleteTestType()
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           datawriter.unregister_instance(sample, ih))
+    assert(fastdds.ReturnCode_t.RETCODE_BAD_PARAMETER ==
+           datawriter.get_key_value(test_sample, ih))
+    
+    # Calling get_key_value with a valid instance should work
+    test_sample = test_complete.KeyedCompleteTestType()
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           datawriter.write(sample, fastdds.c_InstanceHandle_Unknown))
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           datawriter.get_key_value(test_sample, ih))
+    assert(test_sample.id() == sample.id());
+    
+    # Calling get_key_value on a disposed instance should work
+    test_sample = test_complete.KeyedCompleteTestType()
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           datawriter.dispose(sample, ih))
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           datawriter.get_key_value(test_sample, ih))
+    assert(test_sample.id() == sample.id());
+    
 
 def test_get_sending_locators(datawriter):
     """

--- a/fastdds_python/test/api/test_datawriter.py
+++ b/fastdds_python/test/api/test_datawriter.py
@@ -178,17 +178,12 @@ def test_get_key_value(test_keyed_type, datawriter):
     sample = test_complete.KeyedCompleteTestType()
     sample.id(1)
     ih = datawriter.register_instance(sample)
-    wrong_ih = fastdds.InstanceHandle_t()
-    wrong_ih.value[0] = 27;
     assert(fastdds.c_InstanceHandle_Unknown != ih)
-    assert(wrong_ih != ih)
     
-    # Check wrong handles
+    # Check wrong handle
     test_sample = test_complete.KeyedCompleteTestType()
     assert(fastdds.ReturnCode_t.RETCODE_BAD_PARAMETER ==
            datawriter.get_key_value(test_sample, fastdds.c_InstanceHandle_Unknown))
-    assert(fastdds.ReturnCode_t.RETCODE_BAD_PARAMETER ==
-           datawriter.get_key_value(test_sample, wrong_ih))
     
     # Check wrong sample
     assert(fastdds.ReturnCode_t.RETCODE_BAD_PARAMETER ==


### PR DESCRIPTION
Method DataWriter::get_key_value was implemented on Fast DDS, but the python binding tests still expected `UNSUPPORTED` to be returned. This PR adds proper tests for that API.