### PR TITLE
Fix DomainParticipant and DataReader tests failing due to API changes

### DIFF
--- a/fastdds_python/test/api/test_datareader.py
+++ b/fastdds_python/test/api/test_datareader.py
@@ -118,9 +118,9 @@ def test_create_querycondition(datareader):
     - DataReader::create_querycondition
     - DataReader::delete_contained_entities
     """
-    sv = fastdds.SampleStateKindVector()
-    vv = fastdds.ViewStateKindVector()
-    iv = fastdds.InstanceStateKindVector()
+    sv = fastdds.ANY_SAMPLE_STATE
+    vv = fastdds.ANY_VIEW_STATE
+    iv = fastdds.ANY_INSTANCE_STATE
     qp = fastdds.StringVector()
 
     querycondition = datareader.create_querycondition(
@@ -136,9 +136,10 @@ def test_create_readcondition(datareader):
     - DataReader::create_readcondition
     - DataReader::delete_readcondition
     """
-    sv = fastdds.SampleStateKindVector()
-    vv = fastdds.ViewStateKindVector()
-    iv = fastdds.InstanceStateKindVector()
+    sv = fastdds.ANY_SAMPLE_STATE
+    vv = fastdds.ANY_VIEW_STATE
+    iv = fastdds.ANY_INSTANCE_STATE
+
     readcondition = datareader.create_readcondition(
                sv, vv, iv)
     assert(readcondition is None)

--- a/fastdds_python/test/api/test_domainparticipant.py
+++ b/fastdds_python/test/api/test_domainparticipant.py
@@ -716,11 +716,10 @@ def test_find_topic(participant):
     assert(topic is not None)
 
     topic_copy = participant.find_topic("Complete", fastdds.Duration_t(1, 0))
-    assert(topic_copy is None)  # Not implemented yet
-    # assert(topic.get_type_name() == topic_copy.get_type_name())
-    # assert(topic.get_name() == topic_copy.get_name())
-    # assert(fastdds.ReturnCode_t.RETCODE_OK ==
-    #        participant.delete_topic(topic_copy))
+    assert(topic.get_type_name() == topic_copy.get_type_name())
+    assert(topic.get_name() == topic_copy.get_name())
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           participant.delete_topic(topic_copy))
 
     assert(fastdds.ReturnCode_t.RETCODE_OK ==
            participant.delete_topic(topic))

--- a/fastdds_python/test/api/test_subscriber.py
+++ b/fastdds_python/test/api/test_subscriber.py
@@ -39,6 +39,8 @@ def subscriber(participant, topic):
     yield subscriber
 
     assert(fastdds.ReturnCode_t.RETCODE_OK ==
+           subscriber.delete_contained_entities())
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
            participant.delete_subscriber(subscriber))
     assert(fastdds.ReturnCode_t.RETCODE_OK ==
            participant.delete_topic(topic))
@@ -259,6 +261,7 @@ def test_create_datareader_with_profile(topic, subscriber):
                 topic, 'test_datareader_profile', listnr, status_mask_2)
         assert(datareader is not None)
         assert(datareader.is_enabled())
+        qos = datareader.get_qos()
         assert(fastdds.RELIABLE_RELIABILITY_QOS ==
                qos.reliability().kind)
         assert(status_mask_2 == datareader.get_status_mask())


### PR DESCRIPTION
Some test were failing due to the following:

`find_topic` is no longer unsupported.
`create_readcondition` and `create_querycondition` now receive masks instead of vectors.

Signed-off-by: Javier Santiago <javiersantiago@eprosima.com>