### PR TITLE
[18057] Fix ignore participant check

### DIFF
--- a/fastdds_python/test/api/test_domainparticipant.py
+++ b/fastdds_python/test/api/test_domainparticipant.py
@@ -929,9 +929,8 @@ def test_ignore_participant(participant):
     """
     ih = fastdds.InstanceHandle_t()
     ih.value = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
-    assert(fastdds.ReturnCode_t.RETCODE_UNSUPPORTED ==
+    assert(fastdds.ReturnCode_t.RETCODE_OK ==
            participant.ignore_participant(ih))
-
 
 def test_ignore_publication(participant):
     """


### PR DESCRIPTION
`DomainParticipant::ignore_participant` was implemented with Fast DDS release 2.10.1 but the matching Fast DDS-Python test was not updated.