### PR TITLE
[19461] Set Fast CDR version to 1.1.x

### DIFF
--- a/fastdds_python.repos
+++ b/fastdds_python.repos
@@ -6,7 +6,7 @@ repositories:
     fastcdr:
         type: git
         url: https://github.com/eProsima/Fast-CDR.git
-        version: master
+        version: 1.1.x
     fastdds:
         type: git
         url: https://github.com/eProsima/Fast-DDS.git


### PR DESCRIPTION
eProsima/Fast-CDR#156 inlcudes API breaks in Fast CDR which make it incompatible with Fast DDS until eProsima/Fast-DDS#3828 is merged. Until then, this repository should use Fast CDR 1.1.x