### PR TITLE
[20176] Regenerate Fast DDS docs example types due to Gen release v3.2.1

### DIFF
--- a/fastdds_python/test/types/test_completePubSubTypes.cxx
+++ b/fastdds_python/test/types/test_completePubSubTypes.cxx
@@ -36,7 +36,7 @@ StructTypePubSubType::StructTypePubSubType()
     setName("StructType");
     uint32_t type_size =
 #if FASTCDR_VERSION_MAJOR == 1
-        StructType::getMaxCdrSerializedSize();
+        static_cast<uint32_t>(StructType::getMaxCdrSerializedSize());
 #else
         StructType_max_cdr_typesize;
 #endif
@@ -139,23 +139,24 @@ std::function<uint32_t()> StructTypePubSubType::getSerializedSizeProvider(
     return [data, data_representation]() -> uint32_t
            {
 #if FASTCDR_VERSION_MAJOR == 1
-                return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<StructType*>(data))) +
+               static_cast<void>(data_representation);
+               return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<StructType*>(data))) +
                       4u /*encapsulation*/;
 #else
-                try
-                {
-                    eprosima::fastcdr::CdrSizeCalculator calculator(
-                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
-                    size_t current_alignment {0};
-                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                *static_cast<StructType*>(data), current_alignment)) +
-                            4u /*encapsulation*/;
-                }
-                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
-                {
-                    return 0;
-                }
+               try
+               {
+                   eprosima::fastcdr::CdrSizeCalculator calculator(
+                       data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                       eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                   size_t current_alignment {0};
+                   return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                               *static_cast<StructType*>(data), current_alignment)) +
+                           4u /*encapsulation*/;
+               }
+               catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+               {
+                   return 0;
+               }
 #endif // FASTCDR_VERSION_MAJOR == 1
            };
 }
@@ -231,7 +232,7 @@ CompleteTestTypePubSubType::CompleteTestTypePubSubType()
     setName("CompleteTestType");
     uint32_t type_size =
 #if FASTCDR_VERSION_MAJOR == 1
-        CompleteTestType::getMaxCdrSerializedSize();
+        static_cast<uint32_t>(CompleteTestType::getMaxCdrSerializedSize());
 #else
         CompleteTestType_max_cdr_typesize;
 #endif
@@ -334,23 +335,24 @@ std::function<uint32_t()> CompleteTestTypePubSubType::getSerializedSizeProvider(
     return [data, data_representation]() -> uint32_t
            {
 #if FASTCDR_VERSION_MAJOR == 1
-                return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<CompleteTestType*>(data))) +
+               static_cast<void>(data_representation);
+               return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<CompleteTestType*>(data))) +
                       4u /*encapsulation*/;
 #else
-                try
-                {
-                    eprosima::fastcdr::CdrSizeCalculator calculator(
-                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
-                    size_t current_alignment {0};
-                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                *static_cast<CompleteTestType*>(data), current_alignment)) +
-                            4u /*encapsulation*/;
-                }
-                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
-                {
-                    return 0;
-                }
+               try
+               {
+                   eprosima::fastcdr::CdrSizeCalculator calculator(
+                       data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                       eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                   size_t current_alignment {0};
+                   return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                               *static_cast<CompleteTestType*>(data), current_alignment)) +
+                           4u /*encapsulation*/;
+               }
+               catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+               {
+                   return 0;
+               }
 #endif // FASTCDR_VERSION_MAJOR == 1
            };
 }
@@ -422,7 +424,7 @@ KeyedCompleteTestTypePubSubType::KeyedCompleteTestTypePubSubType()
     setName("KeyedCompleteTestType");
     uint32_t type_size =
 #if FASTCDR_VERSION_MAJOR == 1
-        KeyedCompleteTestType::getMaxCdrSerializedSize();
+        static_cast<uint32_t>(KeyedCompleteTestType::getMaxCdrSerializedSize());
 #else
         KeyedCompleteTestType_max_cdr_typesize;
 #endif
@@ -525,23 +527,24 @@ std::function<uint32_t()> KeyedCompleteTestTypePubSubType::getSerializedSizeProv
     return [data, data_representation]() -> uint32_t
            {
 #if FASTCDR_VERSION_MAJOR == 1
-                return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<KeyedCompleteTestType*>(data))) +
+               static_cast<void>(data_representation);
+               return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<KeyedCompleteTestType*>(data))) +
                       4u /*encapsulation*/;
 #else
-                try
-                {
-                    eprosima::fastcdr::CdrSizeCalculator calculator(
-                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
-                    size_t current_alignment {0};
-                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                *static_cast<KeyedCompleteTestType*>(data), current_alignment)) +
-                            4u /*encapsulation*/;
-                }
-                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
-                {
-                    return 0;
-                }
+               try
+               {
+                   eprosima::fastcdr::CdrSizeCalculator calculator(
+                       data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                       eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                   size_t current_alignment {0};
+                   return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                               *static_cast<KeyedCompleteTestType*>(data), current_alignment)) +
+                           4u /*encapsulation*/;
+               }
+               catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+               {
+                   return 0;
+               }
 #endif // FASTCDR_VERSION_MAJOR == 1
            };
 }

--- a/fastdds_python/test/types/test_included_modulesPubSubTypes.cxx
+++ b/fastdds_python/test/types/test_included_modulesPubSubTypes.cxx
@@ -38,7 +38,7 @@ namespace eprosima {
             setName("eprosima::test2::StructType2");
             uint32_t type_size =
         #if FASTCDR_VERSION_MAJOR == 1
-                StructType2::getMaxCdrSerializedSize();
+                static_cast<uint32_t>(StructType2::getMaxCdrSerializedSize());
         #else
                 eprosima_test2_StructType2_max_cdr_typesize;
         #endif
@@ -141,23 +141,24 @@ namespace eprosima {
             return [data, data_representation]() -> uint32_t
                    {
         #if FASTCDR_VERSION_MAJOR == 1
-                        return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<StructType2*>(data))) +
+                       static_cast<void>(data_representation);
+                       return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<StructType2*>(data))) +
                               4u /*encapsulation*/;
         #else
-                        try
-                        {
-                            eprosima::fastcdr::CdrSizeCalculator calculator(
-                                data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                                eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
-                            size_t current_alignment {0};
-                            return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                        *static_cast<StructType2*>(data), current_alignment)) +
-                                    4u /*encapsulation*/;
-                        }
-                        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
-                        {
-                            return 0;
-                        }
+                       try
+                       {
+                           eprosima::fastcdr::CdrSizeCalculator calculator(
+                               data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                               eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                           size_t current_alignment {0};
+                           return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                                       *static_cast<StructType2*>(data), current_alignment)) +
+                                   4u /*encapsulation*/;
+                       }
+                       catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                       {
+                           return 0;
+                       }
         #endif // FASTCDR_VERSION_MAJOR == 1
                    };
         }

--- a/fastdds_python/test/types/test_modulesPubSubTypes.cxx
+++ b/fastdds_python/test/types/test_modulesPubSubTypes.cxx
@@ -38,7 +38,7 @@ namespace eprosima {
             setName("eprosima::test::StructType");
             uint32_t type_size =
         #if FASTCDR_VERSION_MAJOR == 1
-                StructType::getMaxCdrSerializedSize();
+                static_cast<uint32_t>(StructType::getMaxCdrSerializedSize());
         #else
                 eprosima_test_StructType_max_cdr_typesize;
         #endif
@@ -141,23 +141,24 @@ namespace eprosima {
             return [data, data_representation]() -> uint32_t
                    {
         #if FASTCDR_VERSION_MAJOR == 1
-                        return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<StructType*>(data))) +
+                       static_cast<void>(data_representation);
+                       return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<StructType*>(data))) +
                               4u /*encapsulation*/;
         #else
-                        try
-                        {
-                            eprosima::fastcdr::CdrSizeCalculator calculator(
-                                data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                                eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
-                            size_t current_alignment {0};
-                            return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                        *static_cast<StructType*>(data), current_alignment)) +
-                                    4u /*encapsulation*/;
-                        }
-                        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
-                        {
-                            return 0;
-                        }
+                       try
+                       {
+                           eprosima::fastcdr::CdrSizeCalculator calculator(
+                               data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                               eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                           size_t current_alignment {0};
+                           return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                                       *static_cast<StructType*>(data), current_alignment)) +
+                                   4u /*encapsulation*/;
+                       }
+                       catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                       {
+                           return 0;
+                       }
         #endif // FASTCDR_VERSION_MAJOR == 1
                    };
         }
@@ -233,7 +234,7 @@ namespace eprosima {
             setName("eprosima::test::CompleteTestType");
             uint32_t type_size =
         #if FASTCDR_VERSION_MAJOR == 1
-                CompleteTestType::getMaxCdrSerializedSize();
+                static_cast<uint32_t>(CompleteTestType::getMaxCdrSerializedSize());
         #else
                 eprosima_test_CompleteTestType_max_cdr_typesize;
         #endif
@@ -336,23 +337,24 @@ namespace eprosima {
             return [data, data_representation]() -> uint32_t
                    {
         #if FASTCDR_VERSION_MAJOR == 1
-                        return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<CompleteTestType*>(data))) +
+                       static_cast<void>(data_representation);
+                       return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<CompleteTestType*>(data))) +
                               4u /*encapsulation*/;
         #else
-                        try
-                        {
-                            eprosima::fastcdr::CdrSizeCalculator calculator(
-                                data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                                eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
-                            size_t current_alignment {0};
-                            return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                        *static_cast<CompleteTestType*>(data), current_alignment)) +
-                                    4u /*encapsulation*/;
-                        }
-                        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
-                        {
-                            return 0;
-                        }
+                       try
+                       {
+                           eprosima::fastcdr::CdrSizeCalculator calculator(
+                               data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                               eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                           size_t current_alignment {0};
+                           return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                                       *static_cast<CompleteTestType*>(data), current_alignment)) +
+                                   4u /*encapsulation*/;
+                       }
+                       catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                       {
+                           return 0;
+                       }
         #endif // FASTCDR_VERSION_MAJOR == 1
                    };
         }
@@ -424,7 +426,7 @@ namespace eprosima {
             setName("eprosima::test::KeyedCompleteTestType");
             uint32_t type_size =
         #if FASTCDR_VERSION_MAJOR == 1
-                KeyedCompleteTestType::getMaxCdrSerializedSize();
+                static_cast<uint32_t>(KeyedCompleteTestType::getMaxCdrSerializedSize());
         #else
                 eprosima_test_KeyedCompleteTestType_max_cdr_typesize;
         #endif
@@ -527,23 +529,24 @@ namespace eprosima {
             return [data, data_representation]() -> uint32_t
                    {
         #if FASTCDR_VERSION_MAJOR == 1
-                        return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<KeyedCompleteTestType*>(data))) +
+                       static_cast<void>(data_representation);
+                       return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<KeyedCompleteTestType*>(data))) +
                               4u /*encapsulation*/;
         #else
-                        try
-                        {
-                            eprosima::fastcdr::CdrSizeCalculator calculator(
-                                data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                                eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
-                            size_t current_alignment {0};
-                            return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                        *static_cast<KeyedCompleteTestType*>(data), current_alignment)) +
-                                    4u /*encapsulation*/;
-                        }
-                        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
-                        {
-                            return 0;
-                        }
+                       try
+                       {
+                           eprosima::fastcdr::CdrSizeCalculator calculator(
+                               data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                               eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                           size_t current_alignment {0};
+                           return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                                       *static_cast<KeyedCompleteTestType*>(data), current_alignment)) +
+                                   4u /*encapsulation*/;
+                       }
+                       catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                       {
+                           return 0;
+                       }
         #endif // FASTCDR_VERSION_MAJOR == 1
                    };
         }

--- a/fastdds_python_examples/HelloWorldExample/HelloWorldPubSubTypes.cxx
+++ b/fastdds_python_examples/HelloWorldExample/HelloWorldPubSubTypes.cxx
@@ -36,7 +36,7 @@ HelloWorldPubSubType::HelloWorldPubSubType()
     setName("HelloWorld");
     uint32_t type_size =
 #if FASTCDR_VERSION_MAJOR == 1
-        HelloWorld::getMaxCdrSerializedSize();
+        static_cast<uint32_t>(HelloWorld::getMaxCdrSerializedSize());
 #else
         HelloWorld_max_cdr_typesize;
 #endif
@@ -139,23 +139,24 @@ std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
     return [data, data_representation]() -> uint32_t
            {
 #if FASTCDR_VERSION_MAJOR == 1
-                return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<HelloWorld*>(data))) +
+               static_cast<void>(data_representation);
+               return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<HelloWorld*>(data))) +
                       4u /*encapsulation*/;
 #else
-                try
-                {
-                    eprosima::fastcdr::CdrSizeCalculator calculator(
-                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
-                    size_t current_alignment {0};
-                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                *static_cast<HelloWorld*>(data), current_alignment)) +
-                            4u /*encapsulation*/;
-                }
-                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
-                {
-                    return 0;
-                }
+               try
+               {
+                   eprosima::fastcdr::CdrSizeCalculator calculator(
+                       data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                       eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                   size_t current_alignment {0};
+                   return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                               *static_cast<HelloWorld*>(data), current_alignment)) +
+                           4u /*encapsulation*/;
+               }
+               catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+               {
+                   return 0;
+               }
 #endif // FASTCDR_VERSION_MAJOR == 1
            };
 }


### PR DESCRIPTION
This PR regenerates the example types and the test types.
This is needed to introduce the Fast DDS Gen release v3.2.1 changes.