### PR TITLE
[20023] Set proper version on fastdds_python.repos

### DIFF
--- a/fastdds_python.repos
+++ b/fastdds_python.repos
@@ -14,7 +14,7 @@ repositories:
     fastdds_python:
         type: git
         url: https://github.com/eProsima/Fast-DDS-python.git
-        version: 2.1.x
+        version: 1.2.x
     fastddsgen:
         type: git
         url: https://github.com/eProsima/Fast-DDS-Gen.git


### PR DESCRIPTION
The `fastdds_python.repos` file had a typo in the fastdds_python section
This PR fixes it