### PR TITLE
[20486] Fix redefinition of _wrap___eq__ (backport #73)

### DIFF
--- a/fastdds_python/src/swig/fastrtps/types/TypesBase.i
+++ b/fastdds_python/src/swig/fastrtps/types/TypesBase.i
@@ -40,6 +40,9 @@
 %ignore eprosima::fastrtps::types::TypeFlag::deserialize;
 %ignore eprosima::fastrtps::types::TypeFlag::getCdrSerializedSize;
 
+%ignore eprosima::fastrtps::types::operator==;
+%ignore eprosima::fastrtps::types::operator!=;
+
 %include "fastrtps/types/TypesBase.h"
 
 %extend eprosima::fastrtps::types::ReturnCode_t {


### PR DESCRIPTION
This PR backports in 1.0.x the fix introduced here
- #73 