### PR TITLE
[20486] Bump version to v1.0.2 & update .repos

### DIFF
--- a/fastdds_python.repos
+++ b/fastdds_python.repos
@@ -2,25 +2,25 @@ repositories:
     foonathan_memory_vendor:
         type: git
         url: https://github.com/eProsima/foonathan_memory_vendor.git
-        version: master
+        version: v1.2.1
     fastcdr:
         type: git
         url: https://github.com/eProsima/Fast-CDR.git
-        version: master
+        version: v1.0.24
     fastdds:
         type: git
         url: https://github.com/eProsima/Fast-DDS.git
-        version: master
+        version: 2.6.x
     fastdds_python:
         type: git
         url: https://github.com/eProsima/Fast-DDS-python.git
-        version: main
+        version: 1.0.x
     fastddsgen:
         type: git
         url: https://github.com/eProsima/Fast-DDS-Gen.git
-        version: master
+        version: v2.1.2
     fastddsgen/thirdparty/idl-parser:
         type: git
         url: https://github.com/eProsima/IDL-Parser.git
-        version: master
+        version: v1.2.0
 

--- a/fastdds_python/CMakeLists.txt
+++ b/fastdds_python/CMakeLists.txt
@@ -24,7 +24,7 @@ if(POLICY CMP0086)
   cmake_policy(SET CMP0086 NEW)
 endif()
 
-project(fastdds_python VERSION 1.0.1)
+project(fastdds_python VERSION 1.0.2)
 
 ###############################################################################
 # Dependencies


### PR DESCRIPTION
This PR bumps the version to 1.0.2 and set the proper fixed versions in the .repos file for 1.0.x (wrongly setup to master/main).