### PR TITLE
[20734] Hotfix: type regeneration script

### DIFF
--- a/fastdds_python_examples/HelloWorldExample/CMakeLists.txt
+++ b/fastdds_python_examples/HelloWorldExample/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.22)
 
 # SWIG: use standard target name.
 if(POLICY CMP0078)

--- a/utils/scripts/update_generated_code_from_idl.sh
+++ b/utils/scripts/update_generated_code_from_idl.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-idl_files=(
-    './fastdds_python/test/types/test_modules.idl'
-    './fastdds_python/test/types/test_complete.idl'
-    './fastdds_python/test/types/test_included_modules.idl'
-    './fastdds_python_examples/HelloWorldExample/HelloWorld.idl'
-)
-
 red='\E[1;31m'
 yellow='\E[1;33m'
 textreset='\E[1;0m'
@@ -25,22 +18,26 @@ fi
 
 ret_value=0
 
-for idl_file in "${idl_files[@]}"; do
-    idl_dir=$(dirname "${idl_file}")
-    file_from_gen=$(basename "${idl_file}")
+cd ./fastdds_python/test/types
+echo -e "Processing ${yellow}test_complete.idl test_modules.idl${textreset}"
+echo "Running: fastddsgen -cdr both -replace -python test_complete.idl test_modules.idl"
+fastddsgen -cdr both -replace -python test_complete.idl test_modules.idl
+if [[ $? != 0 ]]; then
+    ret_value=-1
+fi
+cd -
 
-    echo -e "Processing ${yellow}${idl_file}${textreset}"
+if [[ $ret_value != -1 ]]; then
+    cd "./fastdds_python_examples/HelloWorldExample"
 
-    cd "${idl_dir}"
+echo -e "Processing ${yellow}HelloWorld.idl${textreset}"
+    echo "Running: fastddsgen -cdr both -replace -python HelloWorld.idl"
+    fastddsgen -cdr both -replace -python HelloWorld.idl
+fi
 
-    echo "Running: fastddsgen -cdr both -replace -flat-output-dir -python ${file_from_gen}"
-    fastddsgen -cdr both -replace -flat-output-dir -python ${file_from_gen}
-
-    if [[ $? != 0 ]]; then
-        ret_value=-1
-    fi
-
-    cd -
-done
+if [[ $? != 0 ]]; then
+    ret_value=-1
+fi
+cd -
 
 exit ${ret_value}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

#108 generalized the script to autogenerate the code related to the types contained in the repository. This script did not take into account that the python types contained in the same folder overwrite the generated CMakeLists.txt file if not passed together to Fast DDS-Gen in the same command. This PR fixes this issue.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.4.x 1.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- [N/A] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [N/A] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
