### PR TITLE
[20893] Prepare 3.0.x-devel to become main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,11 @@
 
 ## Contributor Checklist
 
+<!--
+    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
+    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
+-->
+
 - [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
 - [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
 - [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,7 +18,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,11 +14,11 @@ on:
       fastdds_branch:
         description: 'Fast DDS branch to be used'
         required: false
-        default: '3.0.x-devel'
+        default: 'master'
   pull_request:
   push:
     branches:
-      - 3.0.x-devel
+      - master
   schedule:
     - cron: '0 0 * * *'
 
@@ -36,7 +36,7 @@ jobs:
           - ${{ github.event.inputs.foonathan_memory_vendor_branch || 'master' }}
         fastcdr_version: ${{ fromJson(github.event.inputs.fastcdr_versions || '["master"]') }}
         fastdds_version:
-          - ${{ github.event.inputs.fastdds_branch || '3.0.x-devel' }}
+          - ${{ github.event.inputs.fastdds_branch || 'master' }}
 
     env:
       CXXFLAGS: /MP
@@ -155,7 +155,7 @@ jobs:
           - ${{ github.event.inputs.foonathan_memory_vendor_branch || 'master' }}
         fastcdr_version: ${{ fromJson(github.event.inputs.fastcdr_versions || '["master"]') }}
         fastdds_version:
-          - ${{ github.event.inputs.fastdds_branch || '3.0.x-devel' }}
+          - ${{ github.event.inputs.fastdds_branch || 'master' }}
 
 
     steps:

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -3,15 +3,18 @@ on:
   push:
     branches:
       - 'main'
+      - '1.4.x'
 jobs:
-  mirror_job:
+  mirror_job_main:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     name: Mirror main branch to compatible minor version branches
     strategy:
       fail-fast: false
       matrix:
         dest_branch:
-          - '1.4.x'
+          - '2.0.x'
+          - '2.x'
     steps:
     - name: Mirror action step
       id: mirror
@@ -19,4 +22,22 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         source: 'main'
+        dest: ${{ matrix.dest_branch }}
+
+  mirror_job_1_x:
+    if: github.ref == 'refs/heads/1.4.x'
+    runs-on: ubuntu-latest
+    name: Mirror main branch to compatible minor version branches
+    strategy:
+      fail-fast: false
+      matrix:
+        dest_branch:
+          - '1.x'
+    steps:
+    - name: Mirror action step
+      id: mirror
+      uses: eProsima/eProsima-CI/external/mirror-branch-action@v0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        source: '1.4.x'
         dest: ${{ matrix.dest_branch }}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 [![Forks](https://img.shields.io/github/forks/eProsima/Fast-DDS-python.svg)](https://github.com/eProsima/Fast-DDS-python/network/members)
 [![Stars](https://img.shields.io/github/stars/eProsima/Fast-DDS-python.svg)](https://github.com/eProsima/Fast-DDS-python/stargazers)
 
+<!-- TODO(eduponz): Remove this before releasing v3.0.0 -->
+> [!WARNING]
+> In preparation for v2.0.0 (bindings for Fast DDS v3.0.0), Fast DDS Python's master branch is undergoing major changes entailing **API breaks**.
+> Until Fast DDS Python v2.0.0 is released, it is strongly advisable to use the latest stable version, [v1.4.1](https://github.com/eProsima/Fast-DDS-python/tree/v1.4.1).
 
 *eProsima Fast DDS Python* is a Python binding for the [*eProsima Fast DDS*](https://github.com/eProsima/Fast-DDS) C++ library.
 This is a work in progress, but ultimately the goal is having the complete *Fast DDS* API available in Python.

--- a/fastdds_python/CMakeLists.txt
+++ b/fastdds_python/CMakeLists.txt
@@ -24,7 +24,7 @@ if(POLICY CMP0086)
   cmake_policy(SET CMP0086 NEW)
 endif()
 
-project(fastdds_python VERSION 1.4.1)
+project(fastdds_python VERSION 2.0.0)
 
 # Set BUILD_TESTING to OFF by default.
 if(NOT BUILD_TESTING)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR prepares the 3.0.x-devel branch to become Fast DDS Python main

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.4.x 1.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
