### PR TITLE
[21120] Adjust for API changes in RTPS reader APIs

### DIFF
--- a/.github/workflows/test.meta
+++ b/.github/workflows/test.meta
@@ -1,17 +1,8 @@
-{
-    "names":
-    {
-        "fastdds":
-        {
-            "cmake-args": [
-                "-DSECURITY=ON"
-            ]
-        },
-        "fastdds_python":
-        {
-            "cmake-args": [
-                "-DBUILD_TESTING=ON"
-            ]
-        }
-    }
-}
+names:
+    fastdds:
+        cmake-args:
+            - "-DSECURITY=ON"
+            - "-DLOG_CONSUMER_DEFAULT=STDOUT"
+    fastdds_python:
+        cmake-args:
+            - "-DBUILD_TESTING=ON"

--- a/fastdds_python/test/api/test_domainparticipant.py
+++ b/fastdds_python/test/api/test_domainparticipant.py
@@ -202,7 +202,7 @@ def test_create_publisher_with_profile(participant):
 
     # Failure
     publisher = participant.create_publisher_with_profile(
-            'no_exits_profile')
+            'no_exists_profile')
     assert(publisher is None)
 
     # Overload 1
@@ -436,7 +436,7 @@ def test_create_subscriber_with_profile(participant):
 
     # Failure
     subscriber = participant.create_subscriber_with_profile(
-            'no_exits_profile')
+            'no_exists_profile')
     assert(subscriber is None)
 
     # Overload 1

--- a/fastdds_python/test/api/test_domainparticipantfactory.py
+++ b/fastdds_python/test/api/test_domainparticipantfactory.py
@@ -125,10 +125,10 @@ def test_create_participant_with_profile():
 
     # Failure
     participant = factory.create_participant_with_profile(
-            'no_exits_profile')
+            'no_exists_profile')
     assert(participant is None)
     participant = factory.create_participant_with_profile(
-            0, 'no_exits_profile')
+            0, 'no_exists_profile')
     assert(participant is None)
 
     # Overload 1

--- a/fastdds_python/test/api/test_publisher.py
+++ b/fastdds_python/test/api/test_publisher.py
@@ -219,7 +219,7 @@ def test_create_datawriter_with_profile(topic, publisher):
 
     # Failure
     datawriter = publisher.create_datawriter_with_profile(
-            topic, 'no_exits_profile')
+            topic, 'no_exists_profile')
     assert(datawriter is None)
 
     # Overload 1

--- a/fastdds_python/test/api/test_qos.py
+++ b/fastdds_python/test/api/test_qos.py
@@ -153,11 +153,11 @@ def test_datareader_qos():
            datareader_qos.durability_service().service_cleanup_delay.nanosec)
 
     # .reliable_reader_qos
-    datareader_qos.reliable_reader_qos().times.initialAcknackDelay.seconds = 34
-    datareader_qos.reliable_reader_qos().times.initialAcknackDelay.nanosec = 32
-    datareader_qos.reliable_reader_qos().times.heartbeatResponseDelay. \
+    datareader_qos.reliable_reader_qos().times.initial_acknack_delay.seconds = 34
+    datareader_qos.reliable_reader_qos().times.initial_acknack_delay.nanosec = 32
+    datareader_qos.reliable_reader_qos().times.heartbeat_response_delay. \
         seconds = 432
-    datareader_qos.reliable_reader_qos().times.heartbeatResponseDelay. \
+    datareader_qos.reliable_reader_qos().times.heartbeat_response_delay. \
         nanosec = 43
     datareader_qos.reliable_reader_qos().disable_positive_ACKs.enabled = True
     datareader_qos.reliable_reader_qos().disable_positive_ACKs.duration. \
@@ -165,13 +165,13 @@ def test_datareader_qos():
     datareader_qos.reliable_reader_qos().disable_positive_ACKs.duration. \
         nanosec = 320
     assert(34 == datareader_qos.reliable_reader_qos().times.
-           initialAcknackDelay.seconds)
+           initial_acknack_delay.seconds)
     assert(32 == datareader_qos.reliable_reader_qos().times.
-           initialAcknackDelay.nanosec)
+           initial_acknack_delay.nanosec)
     assert(432 == datareader_qos.reliable_reader_qos().times.
-           heartbeatResponseDelay.seconds)
+           heartbeat_response_delay.seconds)
     assert(43 == datareader_qos.reliable_reader_qos().times.
-           heartbeatResponseDelay.nanosec)
+           heartbeat_response_delay.nanosec)
     assert(datareader_qos.reliable_reader_qos().
            disable_positive_ACKs.enabled)
     assert(13 == datareader_qos.reliable_reader_qos().
@@ -389,13 +389,13 @@ def test_datareader_qos():
 
     # .reliable_reader_qos
     assert(34 == default_datareader_qos.reliable_reader_qos().times.
-           initialAcknackDelay.seconds)
+           initial_acknack_delay.seconds)
     assert(32 == default_datareader_qos.reliable_reader_qos().times.
-           initialAcknackDelay.nanosec)
+           initial_acknack_delay.nanosec)
     assert(432 == default_datareader_qos.reliable_reader_qos().times.
-           heartbeatResponseDelay.seconds)
+           heartbeat_response_delay.seconds)
     assert(43 == default_datareader_qos.reliable_reader_qos().times.
-           heartbeatResponseDelay.nanosec)
+           heartbeat_response_delay.nanosec)
     assert(default_datareader_qos.reliable_reader_qos().
            disable_positive_ACKs.enabled)
     assert(13 == default_datareader_qos.reliable_reader_qos().

--- a/fastdds_python/test/api/test_subscriber.py
+++ b/fastdds_python/test/api/test_subscriber.py
@@ -222,7 +222,7 @@ def test_create_datareader_with_profile(topic, subscriber):
 
     # Failure
     datareader = subscriber.create_datareader_with_profile(
-            topic, 'no_exits_profile')
+            topic, 'no_exists_profile')
     assert(datareader is None)
 
     # Overload 1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adjusts for the changes introduced in:

* eProsima/Fast-DDS#4875

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.4.x 1.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
