### PR TITLE
Fix warning about memory leak in tests [21177]

### DIFF
--- a/fastdds_python/src/swig/fastdds/dds/core/policy/QosPolicies.i
+++ b/fastdds_python/src/swig/fastdds/dds/core/policy/QosPolicies.i
@@ -58,90 +58,13 @@ namespace dds {
 }
 }
 
-%inline %{
-class OctetResourceLimitedVectorStopIterator {};
-class OctetResourceLimitedVectorIterator {
-public:
-    OctetResourceLimitedVectorIterator(
-            eprosima::fastdds::ResourceLimitedVector<eprosima::fastdds::rtps::octet>::iterator _cur,
-            eprosima::fastdds::ResourceLimitedVector<eprosima::fastdds::rtps::octet>::iterator _end) : cur(_cur), end(_end) {}
-    OctetResourceLimitedVectorIterator* __iter__()
-    {
-        return this;
-    }
-    eprosima::fastdds::ResourceLimitedVector<eprosima::fastdds::rtps::octet>::iterator cur;
-    eprosima::fastdds::ResourceLimitedVector<eprosima::fastdds::rtps::octet>::iterator end;
-};
-%}
 
 // SWIG does not support templates in the generated binding,
 // because not all output languages support them
 // We must explicitly declare the specializations of the templates
-%template(OctetResourceLimitedVector) eprosima::fastdds::ResourceLimitedVector<eprosima::fastdds::rtps::octet>;
+resource_limited_vector_template(OctetResourceLimitedVector, eprosima::fastdds::rtps::octet)
 
 %include "fastdds/dds/core/policy/QosPolicies.hpp"
-
-%include "exception.i"
-%exception OctetResourceLimitedVectorIterator::__next__ {
-    try
-    {
-        $action // calls %extend function __next__() below
-    }
-    catch (OctetResourceLimitedVectorStopIterator)
-    {
-        PyErr_SetString(PyExc_StopIteration, "End of iterator");
-        return nullptr;
-    }
-}
-
-%extend OctetResourceLimitedVectorIterator
-{
-    eprosima::fastdds::rtps::octet __next__()
-    {
-        if ($self->cur != $self->end)
-        {
-            // dereference the iterator and return reference to the object,
-            // after that it increments the iterator
-            return *$self->cur++;
-        }
-        throw OctetResourceLimitedVectorStopIterator();
-    }
-}
-
-%exception eprosima::fastdds::ResourceLimitedVector<eprosima::fastdds::rtps::octet>::__getitem__
-{
-    try
-    {
-        $action
-    }
-    catch(std::out_of_range)
-    {
-        SWIG_exception(SWIG_IndexError, "Index out of bounds");
-    }
-}
-
-%extend eprosima::fastdds::ResourceLimitedVector<eprosima::fastdds::rtps::octet>
-{
-    OctetResourceLimitedVectorIterator __iter__()
-    {
-        // return a constructed Iterator object
-        return OctetResourceLimitedVectorIterator($self->begin(), $self->end());
-    }
-
-    size_t __len__() const
-    {
-        return self->size();
-    }
-
-    eprosima::fastdds::rtps::octet __getitem__(int i)
-    {
-        if (self->size() <= i)
-        {
-            throw std::out_of_range("Index out of bounds");
-        }
-        return (*self)[i];
-    }
-}
 
 %exception eprosima::fastdds::dds::PartitionQosPolicy::__getitem__
 {

--- a/fastdds_python/src/swig/fastdds/utils/collections/ResourceLimitedVector.i
+++ b/fastdds_python/src/swig/fastdds/utils/collections/ResourceLimitedVector.i
@@ -16,6 +16,8 @@
 #include "fastdds/utils/collections/ResourceLimitedVector.hpp"
 %}
 
+%include "exception.i"
+
 // Operator[] is ignored by SWIG because it does not map correctly to target languages
 // mostly because of its dual getter/setter nature
 // We can ignore them and extend to make the getter and setter methods explicit and break the overload
@@ -29,6 +31,7 @@
 %ignore eprosima::fastdds::ResourceLimitedVector::at;
 %ignore eprosima::fastdds::ResourceLimitedVector::front;
 %ignore eprosima::fastdds::ResourceLimitedVector::back;
+%ignore eprosima::fastdds::ResourceLimitedVector::push_back;
 
 // Initializer lists are note supported in SWIG. Ignore the method
 %ignore eprosima::fastdds::ResourceLimitedVector::assign(std::initializer_list<value_type>);
@@ -37,28 +40,109 @@
 // and SWIG does not support it in any case
 %ignore eprosima::fastdds::ResourceLimitedVector::operator const collection_type&;
 
+%exception eprosima::fastdds::ResourceLimitedVector::__getitem__
+{
+    try
+    {
+        $action
+    }
+    catch(std::out_of_range)
+    {
+        SWIG_exception(SWIG_IndexError, "Index out of bounds");
+    }
+}
+
 
 %extend eprosima::fastdds::ResourceLimitedVector {
-    pointer at(size_type pos)
+
+    size_t __len__() const
     {
-        return &($self->at(pos));
+        return self->size();
     }
-    pointer front()
+
+    value_type __getitem__(int i)
     {
-        return &($self->front());
-    }
-    pointer back()
-    {
-        return &($self->back());
+        if (self->size() <= i)
+        {
+            throw std::out_of_range("Index out of bounds");
+        }
+        return (*self)[i];
     }
 
     pointer getitem(size_type n) {
         return &($self->operator[](n));
     }
 
-    void setitem(size_type n, const_pointer v) {
-        $self->operator[](n) = *v;
+    void setitem(size_type n, value_type v) {
+        $self->operator[](n) = v;
+    }
+
+    void append(value_type v) {
+        $self->push_back(v);
     }
 }
 
+
 %include "fastdds/utils/collections/ResourceLimitedVector.hpp"
+
+%define resource_limited_vector_template(name_, value_type_)
+%inline %{
+    class name_ ## StopIterator {};
+    class name_ ## Iterator
+    {
+    public:
+        name_ ## Iterator(
+                typename eprosima::fastdds::ResourceLimitedVector<value_type_>::iterator _cur,
+                typename eprosima::fastdds::ResourceLimitedVector<value_type_>::iterator _end)
+            : cur(_cur)
+            , end(_end)
+        {
+        }
+
+        name_ ## Iterator* __iter__()
+        {
+            return this;
+        }
+        typename eprosima::fastdds::ResourceLimitedVector<value_type_>::iterator cur;
+        typename eprosima::fastdds::ResourceLimitedVector<value_type_>::iterator end;
+    };
+%}
+
+%exception name_ ## Iterator::__next__ {
+    try
+    {
+        $action // calls %extend function __next__() below
+    }
+    catch (name_ ## StopIterator)
+    {
+        PyErr_SetString(PyExc_StopIteration, "End of iterator");
+        return nullptr;
+    }
+}
+
+%extend name_ ## Iterator
+{
+    value_type_ __next__()
+    {
+        if ($self->cur != $self->end)
+        {
+            // dereference the iterator and return reference to the object,
+            // after that it increments the iterator
+            return *$self->cur++;
+        }
+        throw name_ ## StopIterator();
+    }
+}
+
+%template(name_) eprosima::fastdds::ResourceLimitedVector<value_type_>;
+
+%extend eprosima::fastdds::ResourceLimitedVector<value_type_>
+{
+
+    name_ ## Iterator __iter__()
+    {
+        // return a constructed Iterator object
+        return name_ ## Iterator($self->begin(), $self->end());
+    }
+}
+%enddef

--- a/fastdds_python/test/api/test_domainparticipant.py
+++ b/fastdds_python/test/api/test_domainparticipant.py
@@ -916,8 +916,8 @@ def test_get_set_qos(participant):
     """
     qos = fastdds.DomainParticipantQos()
     assert(fastdds.RETCODE_OK == participant.get_qos(qos))
-    qos.user_data().push_back(1)
-    qos.user_data().push_back(2)
+    qos.user_data().append(1)
+    qos.user_data().append(2)
     assert(2 == len(qos.user_data()))
 
     assert(fastdds.RETCODE_OK ==

--- a/fastdds_python/test/api/test_qos.py
+++ b/fastdds_python/test/api/test_qos.py
@@ -76,10 +76,10 @@ def test_datareader_qos():
     assert(2 == datareader_qos.resource_limits().extra_samples)
 
     # .user_data
-    datareader_qos.user_data().push_back(0)
-    datareader_qos.user_data().push_back(1)
-    datareader_qos.user_data().push_back(2)
-    datareader_qos.user_data().push_back(3)
+    datareader_qos.user_data().append(0)
+    datareader_qos.user_data().append(1)
+    datareader_qos.user_data().append(2)
+    datareader_qos.user_data().append(3)
     count = 1
     for user_value in datareader_qos.user_data():
         if 1 == count:
@@ -554,10 +554,10 @@ def test_datawriter_qos():
     assert(33 == datawriter_qos.lifespan().duration.nanosec)
 
     # .user_data
-    datawriter_qos.user_data().push_back(0)
-    datawriter_qos.user_data().push_back(1)
-    datawriter_qos.user_data().push_back(2)
-    datawriter_qos.user_data().push_back(3)
+    datawriter_qos.user_data().append(0)
+    datawriter_qos.user_data().append(1)
+    datawriter_qos.user_data().append(2)
+    datawriter_qos.user_data().append(3)
     count = 1
     for user_value in datawriter_qos.user_data():
         if 1 == count:
@@ -867,10 +867,10 @@ def test_topic_qos():
     topic_qos = fastdds.TopicQos()
 
     # .topic_data
-    topic_qos.topic_data().push_back(0)
-    topic_qos.topic_data().push_back(1)
-    topic_qos.topic_data().push_back(2)
-    topic_qos.topic_data().push_back(3)
+    topic_qos.topic_data().append(0)
+    topic_qos.topic_data().append(1)
+    topic_qos.topic_data().append(2)
+    topic_qos.topic_data().append(3)
     count = 1
     for topic_value in topic_qos.topic_data():
         if 1 == count:
@@ -1085,10 +1085,10 @@ def test_subscriber_qos():
     assert('Partition2' == subscriber_qos.partition()[1])
 
     # .group_data
-    subscriber_qos.group_data().push_back(0)
-    subscriber_qos.group_data().push_back(1)
-    subscriber_qos.group_data().push_back(2)
-    subscriber_qos.group_data().push_back(3)
+    subscriber_qos.group_data().append(0)
+    subscriber_qos.group_data().append(1)
+    subscriber_qos.group_data().append(2)
+    subscriber_qos.group_data().append(3)
     count = 1
     for group_value in subscriber_qos.group_data():
         if 1 == count:
@@ -1169,10 +1169,10 @@ def test_publisher_qos():
     assert('Partition2' == publisher_qos.partition()[1])
 
     # .group_data
-    publisher_qos.group_data().push_back(0)
-    publisher_qos.group_data().push_back(1)
-    publisher_qos.group_data().push_back(2)
-    publisher_qos.group_data().push_back(3)
+    publisher_qos.group_data().append(0)
+    publisher_qos.group_data().append(1)
+    publisher_qos.group_data().append(2)
+    publisher_qos.group_data().append(3)
     count = 1
     for group_value in publisher_qos.group_data():
         if 1 == count:
@@ -1347,10 +1347,10 @@ def test_domain_participant_qos():
     assert(not participant_qos.transport().use_builtin_transports)
 
     # .user_data
-    participant_qos.user_data().push_back(0)
-    participant_qos.user_data().push_back(1)
-    participant_qos.user_data().push_back(2)
-    participant_qos.user_data().push_back(3)
+    participant_qos.user_data().append(0)
+    participant_qos.user_data().append(1)
+    participant_qos.user_data().append(2)
+    participant_qos.user_data().append(3)
     count = 1
     for user_value in participant_qos.user_data():
         if 1 == count:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description

Fixes next message:
```
swig/python detected a memory leak of type 'eprosima::fastrtps::ResourceLimitedVector< unsigned char >::pointer *', no destructor found.
```
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 1.4.x 1.2.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
