### PR TITLE
[21183] Adjust for `const` qualification of all data related inputs in DataWriter APIs

### DIFF
--- a/fastdds_python/test/types/test_completePubSubTypes.cxx
+++ b/fastdds_python/test/types/test_completePubSubTypes.cxx
@@ -57,11 +57,11 @@ StructTypePubSubType::~StructTypePubSubType()
 }
 
 bool StructTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructType* p_type = static_cast<StructType*>(data);
+    const StructType* p_type = static_cast<const StructType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool StructTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> StructTypePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructType*>(data), current_alignment)) +
+                               *static_cast<const StructType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void StructTypePubSubType::deleteData(
 }
 
 bool StructTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool StructTypePubSubType::getKey(
         return false;
     }
 
-    StructType* p_type = static_cast<StructType*>(data);
+    const StructType* p_type = static_cast<const StructType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -252,11 +252,11 @@ CompleteTestTypePubSubType::~CompleteTestTypePubSubType()
 }
 
 bool CompleteTestTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteTestType* p_type = static_cast<CompleteTestType*>(data);
+    const CompleteTestType* p_type = static_cast<const CompleteTestType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -328,7 +328,7 @@ bool CompleteTestTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteTestTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -345,7 +345,7 @@ std::function<uint32_t()> CompleteTestTypePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteTestType*>(data), current_alignment)) +
+                               *static_cast<const CompleteTestType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -368,7 +368,7 @@ void CompleteTestTypePubSubType::deleteData(
 }
 
 bool CompleteTestTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -377,7 +377,7 @@ bool CompleteTestTypePubSubType::getKey(
         return false;
     }
 
-    CompleteTestType* p_type = static_cast<CompleteTestType*>(data);
+    const CompleteTestType* p_type = static_cast<const CompleteTestType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -445,11 +445,11 @@ KeyedCompleteTestTypePubSubType::~KeyedCompleteTestTypePubSubType()
 }
 
 bool KeyedCompleteTestTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedCompleteTestType* p_type = static_cast<KeyedCompleteTestType*>(data);
+    const KeyedCompleteTestType* p_type = static_cast<const KeyedCompleteTestType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -521,7 +521,7 @@ bool KeyedCompleteTestTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedCompleteTestTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -538,7 +538,7 @@ std::function<uint32_t()> KeyedCompleteTestTypePubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedCompleteTestType*>(data), current_alignment)) +
+                               *static_cast<const KeyedCompleteTestType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -561,7 +561,7 @@ void KeyedCompleteTestTypePubSubType::deleteData(
 }
 
 bool KeyedCompleteTestTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -570,7 +570,7 @@ bool KeyedCompleteTestTypePubSubType::getKey(
         return false;
     }
 
-    KeyedCompleteTestType* p_type = static_cast<KeyedCompleteTestType*>(data);
+    const KeyedCompleteTestType* p_type = static_cast<const KeyedCompleteTestType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/fastdds_python/test/types/test_completePubSubTypes.h
+++ b/fastdds_python/test/types/test_completePubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~StructTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -147,14 +147,14 @@ public:
     eProsima_user_DllExport ~CompleteTestTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -163,17 +163,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -238,14 +238,14 @@ public:
     eProsima_user_DllExport ~KeyedCompleteTestTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -254,17 +254,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/fastdds_python/test/types/test_included_modulesPubSubTypes.cxx
+++ b/fastdds_python/test/types/test_included_modulesPubSubTypes.cxx
@@ -59,11 +59,11 @@ namespace eprosima {
         }
 
         bool StructType2PubSubType::serialize(
-                void* data,
+                const void* const data,
                 SerializedPayload_t* payload,
                 DataRepresentationId_t data_representation)
         {
-            StructType2* p_type = static_cast<StructType2*>(data);
+            const StructType2* p_type = static_cast<const StructType2*>(data);
 
             // Object that manages the raw buffer.
             eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -135,7 +135,7 @@ namespace eprosima {
         }
 
         std::function<uint32_t()> StructType2PubSubType::getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 DataRepresentationId_t data_representation)
         {
             return [data, data_representation]() -> uint32_t
@@ -152,7 +152,7 @@ namespace eprosima {
                                eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                            size_t current_alignment {0};
                            return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                       *static_cast<StructType2*>(data), current_alignment)) +
+                                       *static_cast<const StructType2*>(data), current_alignment)) +
                                    4u /*encapsulation*/;
                        }
                        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -175,7 +175,7 @@ namespace eprosima {
         }
 
         bool StructType2PubSubType::getKey(
-                void* data,
+                const void* const data,
                 InstanceHandle_t* handle,
                 bool force_md5)
         {
@@ -184,7 +184,7 @@ namespace eprosima {
                 return false;
             }
 
-            StructType2* p_type = static_cast<StructType2*>(data);
+            const StructType2* p_type = static_cast<const StructType2*>(data);
 
             // Object that manages the raw buffer.
             eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/fastdds_python/test/types/test_included_modulesPubSubTypes.h
+++ b/fastdds_python/test/types/test_included_modulesPubSubTypes.h
@@ -57,14 +57,14 @@ namespace eprosima
             eProsima_user_DllExport ~StructType2PubSubType() override;
 
             eProsima_user_DllExport bool serialize(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::SerializedPayload_t* payload) override
             {
                 return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
             }
 
             eProsima_user_DllExport bool serialize(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::SerializedPayload_t* payload,
                     eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -73,17 +73,17 @@ namespace eprosima
                     void* data) override;
 
             eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                    void* data) override
+                    const void* const data) override
             {
                 return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
             }
 
             eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
             eProsima_user_DllExport bool getKey(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                     bool force_md5 = false) override;
 

--- a/fastdds_python/test/types/test_modulesPubSubTypes.cxx
+++ b/fastdds_python/test/types/test_modulesPubSubTypes.cxx
@@ -59,11 +59,11 @@ namespace eprosima {
         }
 
         bool StructTypePubSubType::serialize(
-                void* data,
+                const void* const data,
                 SerializedPayload_t* payload,
                 DataRepresentationId_t data_representation)
         {
-            StructType* p_type = static_cast<StructType*>(data);
+            const StructType* p_type = static_cast<const StructType*>(data);
 
             // Object that manages the raw buffer.
             eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -135,7 +135,7 @@ namespace eprosima {
         }
 
         std::function<uint32_t()> StructTypePubSubType::getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 DataRepresentationId_t data_representation)
         {
             return [data, data_representation]() -> uint32_t
@@ -152,7 +152,7 @@ namespace eprosima {
                                eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                            size_t current_alignment {0};
                            return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                       *static_cast<StructType*>(data), current_alignment)) +
+                                       *static_cast<const StructType*>(data), current_alignment)) +
                                    4u /*encapsulation*/;
                        }
                        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -175,7 +175,7 @@ namespace eprosima {
         }
 
         bool StructTypePubSubType::getKey(
-                void* data,
+                const void* const data,
                 InstanceHandle_t* handle,
                 bool force_md5)
         {
@@ -184,7 +184,7 @@ namespace eprosima {
                 return false;
             }
 
-            StructType* p_type = static_cast<StructType*>(data);
+            const StructType* p_type = static_cast<const StructType*>(data);
 
             // Object that manages the raw buffer.
             eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -254,11 +254,11 @@ namespace eprosima {
         }
 
         bool CompleteTestTypePubSubType::serialize(
-                void* data,
+                const void* const data,
                 SerializedPayload_t* payload,
                 DataRepresentationId_t data_representation)
         {
-            CompleteTestType* p_type = static_cast<CompleteTestType*>(data);
+            const CompleteTestType* p_type = static_cast<const CompleteTestType*>(data);
 
             // Object that manages the raw buffer.
             eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -330,7 +330,7 @@ namespace eprosima {
         }
 
         std::function<uint32_t()> CompleteTestTypePubSubType::getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 DataRepresentationId_t data_representation)
         {
             return [data, data_representation]() -> uint32_t
@@ -347,7 +347,7 @@ namespace eprosima {
                                eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                            size_t current_alignment {0};
                            return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                       *static_cast<CompleteTestType*>(data), current_alignment)) +
+                                       *static_cast<const CompleteTestType*>(data), current_alignment)) +
                                    4u /*encapsulation*/;
                        }
                        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -370,7 +370,7 @@ namespace eprosima {
         }
 
         bool CompleteTestTypePubSubType::getKey(
-                void* data,
+                const void* const data,
                 InstanceHandle_t* handle,
                 bool force_md5)
         {
@@ -379,7 +379,7 @@ namespace eprosima {
                 return false;
             }
 
-            CompleteTestType* p_type = static_cast<CompleteTestType*>(data);
+            const CompleteTestType* p_type = static_cast<const CompleteTestType*>(data);
 
             // Object that manages the raw buffer.
             eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -447,11 +447,11 @@ namespace eprosima {
         }
 
         bool KeyedCompleteTestTypePubSubType::serialize(
-                void* data,
+                const void* const data,
                 SerializedPayload_t* payload,
                 DataRepresentationId_t data_representation)
         {
-            KeyedCompleteTestType* p_type = static_cast<KeyedCompleteTestType*>(data);
+            const KeyedCompleteTestType* p_type = static_cast<const KeyedCompleteTestType*>(data);
 
             // Object that manages the raw buffer.
             eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -523,7 +523,7 @@ namespace eprosima {
         }
 
         std::function<uint32_t()> KeyedCompleteTestTypePubSubType::getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 DataRepresentationId_t data_representation)
         {
             return [data, data_representation]() -> uint32_t
@@ -540,7 +540,7 @@ namespace eprosima {
                                eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                            size_t current_alignment {0};
                            return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                       *static_cast<KeyedCompleteTestType*>(data), current_alignment)) +
+                                       *static_cast<const KeyedCompleteTestType*>(data), current_alignment)) +
                                    4u /*encapsulation*/;
                        }
                        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -563,7 +563,7 @@ namespace eprosima {
         }
 
         bool KeyedCompleteTestTypePubSubType::getKey(
-                void* data,
+                const void* const data,
                 InstanceHandle_t* handle,
                 bool force_md5)
         {
@@ -572,7 +572,7 @@ namespace eprosima {
                 return false;
             }
 
-            KeyedCompleteTestType* p_type = static_cast<KeyedCompleteTestType*>(data);
+            const KeyedCompleteTestType* p_type = static_cast<const KeyedCompleteTestType*>(data);
 
             // Object that manages the raw buffer.
             eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/fastdds_python/test/types/test_modulesPubSubTypes.h
+++ b/fastdds_python/test/types/test_modulesPubSubTypes.h
@@ -57,14 +57,14 @@ namespace eprosima
             eProsima_user_DllExport ~StructTypePubSubType() override;
 
             eProsima_user_DllExport bool serialize(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::SerializedPayload_t* payload) override
             {
                 return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
             }
 
             eProsima_user_DllExport bool serialize(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::SerializedPayload_t* payload,
                     eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -73,17 +73,17 @@ namespace eprosima
                     void* data) override;
 
             eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                    void* data) override
+                    const void* const data) override
             {
                 return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
             }
 
             eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
             eProsima_user_DllExport bool getKey(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                     bool force_md5 = false) override;
 
@@ -150,14 +150,14 @@ namespace eprosima
             eProsima_user_DllExport ~CompleteTestTypePubSubType() override;
 
             eProsima_user_DllExport bool serialize(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::SerializedPayload_t* payload) override
             {
                 return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
             }
 
             eProsima_user_DllExport bool serialize(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::SerializedPayload_t* payload,
                     eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -166,17 +166,17 @@ namespace eprosima
                     void* data) override;
 
             eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                    void* data) override
+                    const void* const data) override
             {
                 return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
             }
 
             eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
             eProsima_user_DllExport bool getKey(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                     bool force_md5 = false) override;
 
@@ -241,14 +241,14 @@ namespace eprosima
             eProsima_user_DllExport ~KeyedCompleteTestTypePubSubType() override;
 
             eProsima_user_DllExport bool serialize(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::SerializedPayload_t* payload) override
             {
                 return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
             }
 
             eProsima_user_DllExport bool serialize(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::SerializedPayload_t* payload,
                     eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -257,17 +257,17 @@ namespace eprosima
                     void* data) override;
 
             eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                    void* data) override
+                    const void* const data) override
             {
                 return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
             }
 
             eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
             eProsima_user_DllExport bool getKey(
-                    void* data,
+                    const void* const data,
                     eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                     bool force_md5 = false) override;
 

--- a/fastdds_python_examples/HelloWorldExample/HelloWorldPubSubTypes.cxx
+++ b/fastdds_python_examples/HelloWorldExample/HelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ HelloWorldPubSubType::~HelloWorldPubSubType()
 }
 
 bool HelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool HelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<HelloWorld*>(data), current_alignment)) +
+                               *static_cast<const HelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void HelloWorldPubSubType::deleteData(
 }
 
 bool HelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool HelloWorldPubSubType::getKey(
         return false;
     }
 
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/fastdds_python_examples/HelloWorldExample/HelloWorldPubSubTypes.h
+++ b/fastdds_python_examples/HelloWorldExample/HelloWorldPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~HelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adjusts python bindings for:

* eProsima/Fast-DDS#4960

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.4.x 1.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
