### PR TITLE
[20869] Create DomainParticipantExtendedQos.i 

### DIFF
--- a/fastdds_python/src/swig/fastdds.i
+++ b/fastdds_python/src/swig/fastdds.i
@@ -226,6 +226,7 @@ namespace xtypes {
 %include "fastdds/dds/domain/DomainParticipantListener.i"
 %include "fastdds/dds/domain/qos/DomainParticipantFactoryQos.i"
 %include "fastdds/dds/domain/qos/DomainParticipantQos.i"
+%include "fastdds/dds/domain/qos/DomainParticipantExtendedQos.i"
 %include "fastdds/dds/domain/qos/ReplierQos.i"
 %include "fastdds/dds/domain/qos/RequesterQos.i"
 %include "fastdds/dds/domain/DomainParticipant.i"

--- a/fastdds_python/src/swig/fastdds/dds/domain/DomainParticipantFactory.i
+++ b/fastdds_python/src/swig/fastdds/dds/domain/DomainParticipantFactory.i
@@ -51,6 +51,34 @@
     /**
      * Create a Participant.
      *
+     * @param extended_qos DomainParticipantExtendedQos Reference.
+     * @param listener DomainParticipantListener Pointer (default: nullptr)
+     * @param mask StatusMask Reference (default: all)
+     * @return DomainParticipant pointer. (nullptr if not created.)
+     */
+    DomainParticipant* create_participant(
+            const DomainParticipantExtendedQos& extended_qos,
+            DomainParticipantListener* listener = nullptr,
+            const StatusMask& mask = eprosima::fastdds::dds::StatusMask::all())
+    {
+        if (nullptr != listener)
+        {
+            Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
+
+            if (nullptr != director)
+            {
+                SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+                Py_INCREF(director->swig_get_self());
+                SWIG_PYTHON_THREAD_END_BLOCK;
+            }
+        }
+
+        return self->create_participant(extended_qos.domainId(), extended_qos, listener, mask);
+    }
+
+    /**
+     * Create a Participant.
+     *
      * @param domain_id Domain Id.
      * @param profile_name Participant profile name.
      * @param listener DomainParticipantListener Pointer (default: nullptr)

--- a/fastdds_python/src/swig/fastdds/dds/domain/qos/DomainParticipantExtendedQos.i
+++ b/fastdds_python/src/swig/fastdds/dds/domain/qos/DomainParticipantExtendedQos.i
@@ -1,0 +1,19 @@
+// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+%{
+#include "fastdds/dds/domain/qos/DomainParticipantExtendedQos.hpp"
+%}
+
+%include "fastdds/dds/domain/qos/DomainParticipantExtendedQos.hpp"

--- a/fastdds_python/test/api/test_domainparticipantfactory.py
+++ b/fastdds_python/test/api/test_domainparticipantfactory.py
@@ -111,6 +111,16 @@ def test_create_participant():
          m,
          listener)
 
+    # Overload 4
+    extended_qos = fastdds.DomainParticipantExtendedQos()
+    participant = factory.create_participant(
+            extended_qos)
+    assert(participant.is_enabled())
+    assert(fastdds.StatusMask.all() == participant.get_status_mask())
+    assert(participant is not None)
+    assert(fastdds.RETCODE_OK ==
+           factory.delete_participant(participant))
+
 
 def test_create_participant_with_profile():
     """


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
Python binding corresponding to Fast-DDS PR: https://github.com/eProsima/Fast-DDS/pull/4779

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.4.x 1.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [X] The PR has a milestone assigned.
- [X] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- _N/A_: Check CI results: failing tests are unrelated with the changes.
