### PR TITLE
[21114] Remove doxygen warnings (#121)

### DIFF
--- a/fastdds_python/src/swig/fastdds/dds/domain/DomainParticipant.i
+++ b/fastdds_python/src/swig/fastdds/dds/domain/DomainParticipant.i
@@ -84,7 +84,7 @@
             if (nullptr != listener)
             {
                 Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
-    
+
                 if (nullptr != director)
                 {
                     Py_INCREF(director->swig_get_self());
@@ -93,7 +93,7 @@
             if (nullptr != old_listener)
             {
                 Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
-    
+
                 if (nullptr != director)
                 {
                     Py_DECREF(director->swig_get_self());
@@ -287,5 +287,9 @@
 %ignore eprosima::fastdds::dds::DomainParticipant::delete_publisher;
 %ignore eprosima::fastdds::dds::DomainParticipant::delete_subscriber;
 %ignore eprosima::fastdds::dds::DomainParticipant::create_subscriber_with_profile;
+
+// Template for std::vector<DomainParticipant*>
+%template(DomainParticipantVector) std::vector<eprosima::fastdds::dds::DomainParticipant*>;
+%typemap(doctype) std::vector<eprosima::fastdds::dds::DomainParticipant*> "DomainParticipantVector";
 
 %include "fastdds/dds/domain/DomainParticipant.hpp"

--- a/fastdds_python/src/swig/fastdds/dds/publisher/DataWriter.i
+++ b/fastdds_python/src/swig/fastdds/dds/publisher/DataWriter.i
@@ -125,6 +125,7 @@
 
 // Template for std::vector<DataWriter*>
 %template(DataWriterVector) std::vector<eprosima::fastdds::dds::DataWriter*>;
+%typemap(doctype) std::vector<eprosima::fastdds::dds::DataWriter*> "DataWriterVector";
 
 %include "fastdds/dds/publisher/DataWriter.hpp"
 

--- a/fastdds_python/src/swig/fastdds/dds/subscriber/DataReader.i
+++ b/fastdds_python/src/swig/fastdds/dds/subscriber/DataReader.i
@@ -18,7 +18,10 @@
 
 // Template for std::vector<DataReader*>
 %template(DataReaderVector) std::vector<eprosima::fastdds::dds::DataReader*>;
+%typemap(doctype) std::vector<eprosima::fastdds::dds::DataReader*> "DataReaderVector";
+
 %template(SampleInfoSeq) eprosima::fastdds::dds::LoanableSequence<eprosima::fastdds::dds::SampleInfo>;
+%typemap(doctype) eprosima::fastdds::dds::LoanableSequence<eprosima::fastdds::dds::SampleInfo> "SampleInfoSeq";
 %extend eprosima::fastdds::dds::LoanableSequence<eprosima::fastdds::dds::SampleInfo>
 {
     size_t __len__() const
@@ -88,7 +91,7 @@
             if (nullptr != listener)
             {
                 Swig::Director* director = SWIG_DIRECTOR_CAST(listener);
-    
+
                 if (nullptr != director)
                 {
                     Py_INCREF(director->swig_get_self());
@@ -97,7 +100,7 @@
             if (nullptr != old_listener)
             {
                 Swig::Director* director = SWIG_DIRECTOR_CAST(old_listener);
-    
+
                 if (nullptr != director)
                 {
                     Py_DECREF(director->swig_get_self());

--- a/fastdds_python/src/swig/fastdds/rtps/common/InstanceHandle.i
+++ b/fastdds_python/src/swig/fastdds/rtps/common/InstanceHandle.i
@@ -77,6 +77,7 @@ long hash(const eprosima::fastrtps::rtps::InstanceHandle_t& handle)
 
 // Template for std::vector<InstanceHandle_t>
 %template(InstanceHandleVector) std::vector<eprosima::fastrtps::rtps::InstanceHandle_t>;
+%typemap(doctype) std::vector<eprosima::fastrtps::rtps::InstanceHandle_t>"InstanceHandleVector";
 
 %include "fastdds/rtps/common/InstanceHandle.h"
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR is the Fast DDS Python counterpart of:

* eProsima/Fast-DDS#5016
* eProsima/Fast-DDS-docs#796

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 1.2.x 1.0.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
