### PR TITLE
[21329] Update `DataWriter::write` return value as `ReturnCode_t`

### DIFF
--- a/fastdds_python/test/api/test_datareader.py
+++ b/fastdds_python/test/api/test_datareader.py
@@ -685,7 +685,7 @@ def test_get_first_untaken(transient_datareader_qos, datareader,
 
     sample = pytest.dds_type.CompleteTestType()
     sample.int16_field(255)
-    assert(datawriter.write(sample))
+    assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
         fastdds.Duration_t(5, 0)))
@@ -968,7 +968,7 @@ def test_get_unread_count(transient_datareader_qos, datareader,
 
     sample = pytest.dds_type.CompleteTestType()
     sample.int16_field(255)
-    assert(datawriter.write(sample))
+    assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
         fastdds.Duration_t(5, 0)))
@@ -983,7 +983,7 @@ def test_is_sample_valid(transient_datareader_qos, datareader,
     """
     sample = pytest.dds_type.CompleteTestType()
     sample.int16_field(255)
-    assert(datawriter.write(sample))
+    assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
         fastdds.Duration_t(5, 0)))
@@ -1043,7 +1043,7 @@ def test_read(transient_datareader_qos, datareader,
 
     sample = pytest.dds_type.CompleteTestType()
     fill_keyed_complete_test_type(sample, cdr_version)
-    assert(datawriter.write(sample))
+    assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
         fastdds.Duration_t(5, 0)))
@@ -1123,7 +1123,7 @@ def test_read_next_instance(transient_datareader_qos, test_keyed_type,
 
     sample = pytest.dds_type.KeyedCompleteTestType()
     fill_keyed_complete_test_type(sample, cdr_version)
-    assert(datawriter.write(sample))
+    assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
         fastdds.Duration_t(5, 0)))
@@ -1157,7 +1157,7 @@ def test_read_next_sample(transient_datareader_qos, datareader,
 
     sample = pytest.dds_type.CompleteTestType()
     fill_keyed_complete_test_type(sample, cdr_version)
-    assert(datawriter.write(sample))
+    assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
         fastdds.Duration_t(5, 0)))
@@ -1189,7 +1189,7 @@ def test_take(transient_datareader_qos, datareader,
 
     sample = pytest.dds_type.CompleteTestType()
     fill_keyed_complete_test_type(sample, cdr_version)
-    assert(datawriter.write(sample))
+    assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
         fastdds.Duration_t(5, 0)))
@@ -1269,7 +1269,7 @@ def test_take_next_instance(transient_datareader_qos, test_keyed_type,
 
     sample = pytest.dds_type.KeyedCompleteTestType()
     fill_keyed_complete_test_type(sample, cdr_version)
-    assert(datawriter.write(sample))
+    assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
         fastdds.Duration_t(5, 0)))
@@ -1303,7 +1303,7 @@ def test_take_next_sample(transient_datareader_qos, datareader,
 
     sample = pytest.dds_type.CompleteTestType()
     fill_keyed_complete_test_type(sample, cdr_version)
-    assert(datawriter.write(sample))
+    assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
         fastdds.Duration_t(5, 0)))

--- a/fastdds_python/test/api/test_datawriter.py
+++ b/fastdds_python/test/api/test_datawriter.py
@@ -118,7 +118,7 @@ def test_clear_history(keep_all_datawriter_qos, datawriter):
     """
     sample = pytest.dds_type.CompleteTestType()
     sample.int16_field(4)
-    assert(datawriter.write(sample))
+    assert(fastdds.RETCODE_OK == datawriter.write(sample))
     assert([fastdds.RETCODE_OK, 1] ==
            datawriter.clear_history())
 
@@ -497,7 +497,7 @@ def test_wait_for_acknowledgments(test_keyed_type, datawriter):
     # Overload 1
     sample = pytest.dds_type.KeyedCompleteTestType()
     sample.id(3)
-    assert(datawriter.write(sample))
+    assert(fastdds.RETCODE_OK == datawriter.write(sample))
     assert(fastdds.RETCODE_OK ==
            datawriter.wait_for_acknowledgments(fastdds.Duration_t(1, 0)))
 
@@ -517,7 +517,7 @@ def test_write(test_keyed_type, datawriter):
     """
     # Overload 1
     sample = pytest.dds_type.KeyedCompleteTestType()
-    assert(datawriter.write(sample))
+    assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     # Overload 2
     sample = pytest.dds_type.KeyedCompleteTestType()
@@ -530,7 +530,7 @@ def test_write(test_keyed_type, datawriter):
     sequence_number.low = 1
     params.related_sample_identity().writer_guid(guid)
     params.related_sample_identity().sequence_number(sequence_number)
-    assert(datawriter.write(sample, params))
+    assert(fastdds.RETCODE_OK == datawriter.write(sample, params))
 
     # Overload 3
     sample = pytest.dds_type.KeyedCompleteTestType()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR is the corresponding applied to this repo the Fast DDS PR:
- https://github.com/eProsima/Fast-DDS/pull/5049
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.4.x 1.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
