### PR TITLE
[21325] Remove all code related to FAST CDR v1

### DIFF
--- a/fastdds_python/src/swig/fastdds.i
+++ b/fastdds_python/src/swig/fastdds.i
@@ -133,8 +133,10 @@ namespace xtypes {
 // Failing to do so will issue a warning, but will not stop the compilation.
 // However, the resulting derived class will **not** be considered as inheriting from the base class
 
+#ifndef FASTDDS_DOCS_BUILD
 %include <fastcdr/config.h>
 %include "fastcdr/xcdr/optional.i"
+#endif
 
 %include "fastdds/LibrarySettings.i"
 %include "fastdds/rtps/common/VendorId_t.i"

--- a/fastdds_python/src/swig/fastdds.i
+++ b/fastdds_python/src/swig/fastdds.i
@@ -134,9 +134,7 @@ namespace xtypes {
 // However, the resulting derived class will **not** be considered as inheriting from the base class
 
 %include <fastcdr/config.h>
-#if FASTCDR_VERSION_MAJOR > 1
 %include "fastcdr/xcdr/optional.i"
-#endif
 
 %include "fastdds/LibrarySettings.i"
 %include "fastdds/rtps/common/VendorId_t.i"

--- a/fastdds_python/test/CMakeLists.txt
+++ b/fastdds_python/test/CMakeLists.txt
@@ -20,7 +20,6 @@ add_test(NAME api_tests
         ${Python3_EXECUTABLE}
         -m pytest
         -vrP
-        --cdr v2
     WORKING_DIRECTORY
         ${CMAKE_CURRENT_SOURCE_DIR}/api
     )

--- a/fastdds_python/test/CMakeLists.txt
+++ b/fastdds_python/test/CMakeLists.txt
@@ -15,18 +15,12 @@
 # Compile types
 add_subdirectory(types)
 
-set(fastcdr_version_argument "v2")
-if (${fastcdr_VERSION_MAJOR} EQUAL 1)
-    set(fastcdr_version_argument "v1")
-endif()
-
-
 add_test(NAME api_tests
     COMMAND
         ${Python3_EXECUTABLE}
         -m pytest
         -vrP
-        --cdr ${fastcdr_version_argument}
+        --cdr v2
     WORKING_DIRECTORY
         ${CMAKE_CURRENT_SOURCE_DIR}/api
     )

--- a/fastdds_python/test/api/conftest.py
+++ b/fastdds_python/test/api/conftest.py
@@ -1,3 +1,0 @@
-
-def pytest_addoption(parser):
-    parser.addoption("--cdr", action="store", default="v2")

--- a/fastdds_python/test/api/test_datareader.py
+++ b/fastdds_python/test/api/test_datareader.py
@@ -6,10 +6,6 @@ class DataReaderListener (fastdds.DataReaderListener):
     def __init__(self):
         super().__init__()
 
-@pytest.fixture
-def cdr_version(request):
-    return request.config.getoption('--cdr')
-
 @pytest.fixture(params=['no_module', 'module'], autouse=True)
 def data_type(request):
     if request.param == 'no_module':
@@ -112,8 +108,7 @@ def datawriter(writer_participant, writer_topic, publisher):
            factory.delete_participant(writer_participant))
 
 
-# This function should be used in a test which uses 'cdr_version' fixture
-def fill_keyed_complete_test_type(data, cdr_version):
+def fill_keyed_complete_test_type(data):
     # Auxiliary StructTypes
     struct_type1 = pytest.dds_type.StructType()
     struct_type1.char_field('\x01')
@@ -186,34 +181,19 @@ def fill_keyed_complete_test_type(data, cdr_version):
     data.struct_field().string_field("Test string")
     data.struct_field().enum_field(pytest.dds_type.Color_MAGENTA)
     data.struct_field().enum2_field(pytest.dds_type.Material_METAL)
-    if (cdr_version == 'v1'):
-        data.char_opt_field('\x01')
-        data.uint8_opt_field(254)
-        data.int16_opt_field(-10)
-        data.uint16_opt_field(10)
-        data.int32_opt_field(-1000)
-        data.uint32_opt_field(1000)
-        data.int64_opt_field(-36000)
-        data.uint64_opt_field(36000)
-        data.float_opt_field(1.0)
-        data.double_opt_field(1202.5)
-        data.bool_opt_field(True)
-        data.string_opt_field("Test string")
-        data.enum_opt_field(pytest.dds_type.Color_MAGENTA)
-    else:
-        data.char_opt_field().set_value('\x01')
-        data.uint8_opt_field().set_value(254)
-        data.int16_opt_field().set_value(-10)
-        data.uint16_opt_field().set_value(10)
-        data.int32_opt_field().set_value(-1000)
-        data.uint32_opt_field().set_value(1000)
-        data.int64_opt_field().set_value(-36000)
-        data.uint64_opt_field().set_value(36000)
-        data.float_opt_field().set_value(1.0)
-        data.double_opt_field().set_value(1202.5)
-        data.bool_opt_field().set_value(True)
-        data.string_opt_field().set_value("Test string")
-        data.enum_opt_field().set_value(pytest.dds_type.Color_MAGENTA)
+    data.char_opt_field().set_value('\x01')
+    data.uint8_opt_field().set_value(254)
+    data.int16_opt_field().set_value(-10)
+    data.uint16_opt_field().set_value(10)
+    data.int32_opt_field().set_value(-1000)
+    data.uint32_opt_field().set_value(1000)
+    data.int64_opt_field().set_value(-36000)
+    data.uint64_opt_field().set_value(36000)
+    data.float_opt_field().set_value(1.0)
+    data.double_opt_field().set_value(1202.5)
+    data.bool_opt_field().set_value(True)
+    data.string_opt_field().set_value("Test string")
+    data.enum_opt_field().set_value(pytest.dds_type.Color_MAGENTA)
     struct_field = pytest.dds_type.StructType()
     struct_field.char_field('\x01')
     struct_field.uint8_field(254)
@@ -229,10 +209,7 @@ def fill_keyed_complete_test_type(data, cdr_version):
     struct_field.string_field("Test string")
     struct_field.enum_field(pytest.dds_type.Color_MAGENTA)
     struct_field.enum2_field(pytest.dds_type.Material_METAL)
-    if (cdr_version == 'v1'):
-        data.struct_opt_field(struct_field)
-    else:
-        data.struct_opt_field().set_value(struct_field)
+    data.struct_opt_field().set_value(struct_field)
     data.array_char_field(['\x01', '\x02', '\x03'])
     data.array_uint8_field([254, 255, 1])
     data.array_int16_field([-10, 10, -20])
@@ -283,8 +260,7 @@ def fill_keyed_complete_test_type(data, cdr_version):
     data.unbounded_sequence_struct_field([struct_type1, struct_type2, struct_type3])
 
 
-# This function should be used in a test which uses 'cdr_version' fixture
-def check_keyed_complete_test_type(data, cdr_version):
+def check_keyed_complete_test_type(data):
     assert(data.char_field() == '\x01')
     assert(data.uint8_field() == 254)
     assert(data.int16_field() == -10)
@@ -313,49 +289,34 @@ def check_keyed_complete_test_type(data, cdr_version):
     assert(data.struct_field().string_field() == "Test string")
     assert(data.struct_field().enum_field() == pytest.dds_type.Color_MAGENTA)
     assert(data.struct_field().enum2_field() == pytest.dds_type.Material_METAL)
-    if cdr_version == 'v1':
-        assert(data.char_opt_field() == '\x01')
-        assert(data.uint8_opt_field() == 254)
-        assert(data.int16_opt_field() == -10)
-        assert(data.uint16_opt_field() == 10)
-        assert(data.int32_opt_field() == -1000)
-        assert(data.uint32_opt_field() == 1000)
-        assert(data.int64_opt_field() == -36000)
-        assert(data.uint64_opt_field() == 36000)
-        assert(data.float_opt_field() == 1.0)
-        assert(data.double_opt_field() == 1202.5)
-        assert(data.bool_opt_field() == True)
-        assert(data.string_opt_field() == "Test string")
-        assert(data.enum_opt_field() == pytest.dds_type.Color_MAGENTA)
-    else:
-        assert(data.char_opt_field().has_value())
-        assert(data.char_opt_field().get_value() == '\x01')
-        assert(data.uint8_opt_field().has_value())
-        assert(data.uint8_opt_field().get_value() == 254)
-        assert(data.int16_opt_field().has_value())
-        assert(data.int16_opt_field().get_value() == -10)
-        assert(data.uint16_opt_field().has_value())
-        assert(data.uint16_opt_field().get_value() == 10)
-        assert(data.int32_opt_field().has_value())
-        assert(data.int32_opt_field().get_value() == -1000)
-        assert(data.uint32_opt_field().has_value())
-        assert(data.uint32_opt_field().get_value() == 1000)
-        assert(data.int64_opt_field().has_value())
-        assert(data.int64_opt_field().get_value() == -36000)
-        assert(data.uint64_opt_field().has_value())
-        assert(data.uint64_opt_field().get_value() == 36000)
-        assert(data.float_opt_field().has_value())
-        assert(data.float_opt_field().get_value() == 1.0)
-        assert(data.double_opt_field().has_value())
-        assert(data.double_opt_field().get_value() == 1202.5)
-        assert(data.bool_opt_field().has_value())
-        assert(data.bool_opt_field().get_value() == True)
-        assert(data.string_opt_field().has_value())
-        assert(data.string_opt_field().get_value() == "Test string")
-        assert(data.enum_opt_field().has_value())
-        assert(data.enum_opt_field().get_value() == pytest.dds_type.Color_MAGENTA)
-        assert(not data.enum2_opt_field().has_value())
-        assert(data.struct_opt_field().has_value())
+    assert(data.char_opt_field().has_value())
+    assert(data.char_opt_field().get_value() == '\x01')
+    assert(data.uint8_opt_field().has_value())
+    assert(data.uint8_opt_field().get_value() == 254)
+    assert(data.int16_opt_field().has_value())
+    assert(data.int16_opt_field().get_value() == -10)
+    assert(data.uint16_opt_field().has_value())
+    assert(data.uint16_opt_field().get_value() == 10)
+    assert(data.int32_opt_field().has_value())
+    assert(data.int32_opt_field().get_value() == -1000)
+    assert(data.uint32_opt_field().has_value())
+    assert(data.uint32_opt_field().get_value() == 1000)
+    assert(data.int64_opt_field().has_value())
+    assert(data.int64_opt_field().get_value() == -36000)
+    assert(data.uint64_opt_field().has_value())
+    assert(data.uint64_opt_field().get_value() == 36000)
+    assert(data.float_opt_field().has_value())
+    assert(data.float_opt_field().get_value() == 1.0)
+    assert(data.double_opt_field().has_value())
+    assert(data.double_opt_field().get_value() == 1202.5)
+    assert(data.bool_opt_field().has_value())
+    assert(data.bool_opt_field().get_value() == True)
+    assert(data.string_opt_field().has_value())
+    assert(data.string_opt_field().get_value() == "Test string")
+    assert(data.enum_opt_field().has_value())
+    assert(data.enum_opt_field().get_value() == pytest.dds_type.Color_MAGENTA)
+    assert(not data.enum2_opt_field().has_value())
+    assert(data.struct_opt_field().has_value())
     assert(data.struct_opt_field().char_field() == '\x01')
     assert(data.struct_opt_field().uint8_field() == 254)
     assert(data.struct_opt_field().int16_field() == -10)
@@ -989,8 +950,7 @@ def test_lookup_instance(transient_datareader_qos, test_keyed_type, datareader,
     assert(writer_ih == ih)
 
 
-def test_read(transient_datareader_qos, datareader,
-              datawriter, cdr_version):
+def test_read(transient_datareader_qos, datareader, datawriter):
     """
     This test checks:
     - DataReader::read
@@ -1007,7 +967,7 @@ def test_read(transient_datareader_qos, datareader,
     assert(0 == len(info_seq))
 
     sample = pytest.dds_type.CompleteTestType()
-    fill_keyed_complete_test_type(sample, cdr_version)
+    fill_keyed_complete_test_type(sample)
     assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
@@ -1022,13 +982,13 @@ def test_read(transient_datareader_qos, datareader,
     assert(0 < info_seq[0].source_timestamp.to_ns())
     assert(0 < info_seq[0].reception_timestamp.to_ns())
     assert(sample == data_seq[0])
-    check_keyed_complete_test_type(data_seq[0], cdr_version)
+    check_keyed_complete_test_type(data_seq[0])
     assert(fastdds.RETCODE_OK ==
            datareader.return_loan(data_seq, info_seq))
 
 
 def test_read_instance(transient_datareader_qos, test_keyed_type,
-                       datareader, datawriter, cdr_version):
+                       datareader, datawriter):
     """
     This test checks:
     - DataReader::read_instance
@@ -1046,7 +1006,7 @@ def test_read_instance(transient_datareader_qos, test_keyed_type,
     assert(0 == len(info_seq))
 
     sample = pytest.dds_type.KeyedCompleteTestType()
-    fill_keyed_complete_test_type(sample, cdr_version)
+    fill_keyed_complete_test_type(sample)
     ih = datawriter.register_instance(sample)
     assert(fastdds.RETCODE_OK == datawriter.write(sample, ih))
 
@@ -1063,13 +1023,13 @@ def test_read_instance(transient_datareader_qos, test_keyed_type,
     assert(0 < info_seq[0].source_timestamp.to_ns())
     assert(0 < info_seq[0].reception_timestamp.to_ns())
     assert(sample == data_seq[0])
-    check_keyed_complete_test_type(data_seq[0], cdr_version)
+    check_keyed_complete_test_type(data_seq[0])
     assert(fastdds.RETCODE_OK ==
            datareader.return_loan(data_seq, info_seq))
 
 
 def test_read_next_instance(transient_datareader_qos, test_keyed_type,
-                            datareader, datawriter, cdr_version):
+                            datareader, datawriter):
     """
     This test checks:
     - DataReader::read_next_instance
@@ -1087,7 +1047,7 @@ def test_read_next_instance(transient_datareader_qos, test_keyed_type,
     assert(0 == len(info_seq))
 
     sample = pytest.dds_type.KeyedCompleteTestType()
-    fill_keyed_complete_test_type(sample, cdr_version)
+    fill_keyed_complete_test_type(sample)
     assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
@@ -1103,13 +1063,13 @@ def test_read_next_instance(transient_datareader_qos, test_keyed_type,
     assert(0 < info_seq[0].source_timestamp.to_ns())
     assert(0 < info_seq[0].reception_timestamp.to_ns())
     assert(sample == data_seq[0])
-    check_keyed_complete_test_type(data_seq[0], cdr_version)
+    check_keyed_complete_test_type(data_seq[0])
     assert(fastdds.RETCODE_OK ==
            datareader.return_loan(data_seq, info_seq))
 
 
 def test_read_next_sample(transient_datareader_qos, datareader,
-                          datawriter, cdr_version):
+                          datawriter):
     """
     This test checks:
     - DataReader::read_next_sample
@@ -1121,7 +1081,7 @@ def test_read_next_sample(transient_datareader_qos, datareader,
                 data, info))
 
     sample = pytest.dds_type.CompleteTestType()
-    fill_keyed_complete_test_type(sample, cdr_version)
+    fill_keyed_complete_test_type(sample)
     assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
@@ -1132,11 +1092,11 @@ def test_read_next_sample(transient_datareader_qos, datareader,
     assert(0 < info.source_timestamp.to_ns())
     assert(0 < info.reception_timestamp.to_ns())
     assert(sample == data)
-    check_keyed_complete_test_type(data, cdr_version)
+    check_keyed_complete_test_type(data)
 
 
 def test_take(transient_datareader_qos, datareader,
-              datawriter, cdr_version):
+              datawriter):
     """
     This test checks:
     - DataReader::take
@@ -1153,7 +1113,7 @@ def test_take(transient_datareader_qos, datareader,
     assert(0 == len(info_seq))
 
     sample = pytest.dds_type.CompleteTestType()
-    fill_keyed_complete_test_type(sample, cdr_version)
+    fill_keyed_complete_test_type(sample)
     assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
@@ -1168,13 +1128,13 @@ def test_take(transient_datareader_qos, datareader,
     assert(0 < info_seq[0].source_timestamp.to_ns())
     assert(0 < info_seq[0].reception_timestamp.to_ns())
     assert(sample == data_seq[0])
-    check_keyed_complete_test_type(data_seq[0], cdr_version)
+    check_keyed_complete_test_type(data_seq[0])
     assert(fastdds.RETCODE_OK ==
            datareader.return_loan(data_seq, info_seq))
 
 
 def test_take_instance(transient_datareader_qos, test_keyed_type,
-                       datareader, datawriter, cdr_version):
+                       datareader, datawriter):
     """
     This test checks:
     - DataReader::take_instance
@@ -1192,7 +1152,7 @@ def test_take_instance(transient_datareader_qos, test_keyed_type,
     assert(0 == len(info_seq))
 
     sample = pytest.dds_type.KeyedCompleteTestType()
-    fill_keyed_complete_test_type(sample, cdr_version)
+    fill_keyed_complete_test_type(sample)
     ih = datawriter.register_instance(sample)
     assert(fastdds.RETCODE_OK == datawriter.write(sample, ih))
 
@@ -1209,13 +1169,13 @@ def test_take_instance(transient_datareader_qos, test_keyed_type,
     assert(0 < info_seq[0].source_timestamp.to_ns())
     assert(0 < info_seq[0].reception_timestamp.to_ns())
     assert(sample == data_seq[0])
-    check_keyed_complete_test_type(data_seq[0], cdr_version)
+    check_keyed_complete_test_type(data_seq[0])
     assert(fastdds.RETCODE_OK ==
            datareader.return_loan(data_seq, info_seq))
 
 
 def test_take_next_instance(transient_datareader_qos, test_keyed_type,
-                            datareader, datawriter, cdr_version):
+                            datareader, datawriter):
     """
     This test checks:
     - DataReader::take_next_instance
@@ -1233,7 +1193,7 @@ def test_take_next_instance(transient_datareader_qos, test_keyed_type,
     assert(0 == len(info_seq))
 
     sample = pytest.dds_type.KeyedCompleteTestType()
-    fill_keyed_complete_test_type(sample, cdr_version)
+    fill_keyed_complete_test_type(sample)
     assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
@@ -1249,13 +1209,13 @@ def test_take_next_instance(transient_datareader_qos, test_keyed_type,
     assert(0 < info_seq[0].source_timestamp.to_ns())
     assert(0 < info_seq[0].reception_timestamp.to_ns())
     assert(sample == data_seq[0])
-    check_keyed_complete_test_type(data_seq[0], cdr_version)
+    check_keyed_complete_test_type(data_seq[0])
     assert(fastdds.RETCODE_OK ==
            datareader.return_loan(data_seq, info_seq))
 
 
 def test_take_next_sample(transient_datareader_qos, datareader,
-                          datawriter, cdr_version):
+                          datawriter):
     """
     This test checks:
     - DataReader::take_next_sample
@@ -1267,7 +1227,7 @@ def test_take_next_sample(transient_datareader_qos, datareader,
                 data, info))
 
     sample = pytest.dds_type.CompleteTestType()
-    fill_keyed_complete_test_type(sample, cdr_version)
+    fill_keyed_complete_test_type(sample)
     assert(fastdds.RETCODE_OK == datawriter.write(sample))
 
     assert(datareader.wait_for_unread_message(
@@ -1278,7 +1238,7 @@ def test_take_next_sample(transient_datareader_qos, datareader,
     assert(0 < info.source_timestamp.to_ns())
     assert(0 < info.reception_timestamp.to_ns())
     assert(sample == data)
-    check_keyed_complete_test_type(data, cdr_version)
+    check_keyed_complete_test_type(data)
 
 
 def test_get_type(test_type, datareader):

--- a/fastdds_python/test/types/test_complete.i
+++ b/fastdds_python/test/types/test_complete.i
@@ -55,9 +55,7 @@
 %}
 
 %include <fastcdr/config.h>
-#if FASTCDR_VERSION_MAJOR > 1
 %import(module="fastdds") "fastcdr/xcdr/optional.hpp"
-#endif
 %import(module="fastdds") "fastdds/dds/core/LoanableCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableTypedCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableSequence.hpp"
@@ -443,9 +441,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::char_opt_field(char&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(charOpt) eprosima::fastcdr::optional<char>;
@@ -459,7 +454,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::char_opt_field(eprosima::fastcdr::optional<char>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -469,9 +463,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::uint8_opt_field(uint8_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint8_tOpt) eprosima::fastcdr::optional<uint8_t>;
@@ -485,7 +476,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::uint8_opt_field(eprosima::fastcdr::optional<uint8_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -495,9 +485,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::int16_opt_field(int16_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(int16_tOpt) eprosima::fastcdr::optional<int16_t>;
@@ -511,7 +498,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::int16_opt_field(eprosima::fastcdr::optional<int16_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -521,9 +507,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::uint16_opt_field(uint16_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint16_tOpt) eprosima::fastcdr::optional<uint16_t>;
@@ -537,7 +520,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::uint16_opt_field(eprosima::fastcdr::optional<uint16_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -547,9 +529,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::int32_opt_field(int32_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(int32_tOpt) eprosima::fastcdr::optional<int32_t>;
@@ -563,7 +542,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::int32_opt_field(eprosima::fastcdr::optional<int32_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -573,9 +551,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::uint32_opt_field(uint32_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint32_tOpt) eprosima::fastcdr::optional<uint32_t>;
@@ -589,7 +564,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::uint32_opt_field(eprosima::fastcdr::optional<uint32_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -599,9 +573,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::int64_opt_field(int64_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(int64_tOpt) eprosima::fastcdr::optional<int64_t>;
@@ -615,7 +586,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::int64_opt_field(eprosima::fastcdr::optional<int64_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -625,9 +595,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::uint64_opt_field(uint64_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint64_tOpt) eprosima::fastcdr::optional<uint64_t>;
@@ -641,7 +608,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::uint64_opt_field(eprosima::fastcdr::optional<uint64_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -651,9 +617,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::float_opt_field(float&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(floatOpt) eprosima::fastcdr::optional<float>;
@@ -667,7 +630,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::float_opt_field(eprosima::fastcdr::optional<float>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -677,9 +639,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::double_opt_field(double&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(doubleOpt) eprosima::fastcdr::optional<double>;
@@ -693,7 +652,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::double_opt_field(eprosima::fastcdr::optional<double>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -703,9 +661,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::bool_opt_field(bool&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(boolOpt) eprosima::fastcdr::optional<bool>;
@@ -719,7 +674,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::bool_opt_field(eprosima::fastcdr::optional<bool>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -729,9 +683,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::string_opt_field(std::string&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(stringOpt) eprosima::fastcdr::optional<std::string>;
@@ -745,7 +696,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::string_opt_field(eprosima::fastcdr::optional<std::string>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -755,9 +705,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::enum_opt_field(Color&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(ColorOpt) eprosima::fastcdr::optional<Color>;
@@ -771,7 +718,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::enum_opt_field(eprosima::fastcdr::optional<Color>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -781,9 +727,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::enum2_opt_field(Material&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(MaterialOpt) eprosima::fastcdr::optional<Material>;
@@ -797,7 +740,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::enum2_opt_field(eprosima::fastcdr::optional<Material>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -807,9 +749,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore CompleteTestType::struct_opt_field(StructType&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(StructTypeOpt) eprosima::fastcdr::optional<StructType>;
@@ -823,7 +762,6 @@ namespace swig {
   }
 }
 %ignore CompleteTestType::struct_opt_field(eprosima::fastcdr::optional<StructType>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1737,9 +1675,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::char_opt_field(char&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(charOpt) eprosima::fastcdr::optional<char>;
@@ -1753,7 +1688,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::char_opt_field(eprosima::fastcdr::optional<char>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1763,9 +1697,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::uint8_opt_field(uint8_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint8_tOpt) eprosima::fastcdr::optional<uint8_t>;
@@ -1779,7 +1710,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::uint8_opt_field(eprosima::fastcdr::optional<uint8_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1789,9 +1719,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::int16_opt_field(int16_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(int16_tOpt) eprosima::fastcdr::optional<int16_t>;
@@ -1805,7 +1732,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::int16_opt_field(eprosima::fastcdr::optional<int16_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1815,9 +1741,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::uint16_opt_field(uint16_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint16_tOpt) eprosima::fastcdr::optional<uint16_t>;
@@ -1831,7 +1754,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::uint16_opt_field(eprosima::fastcdr::optional<uint16_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1841,9 +1763,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::int32_opt_field(int32_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(int32_tOpt) eprosima::fastcdr::optional<int32_t>;
@@ -1857,7 +1776,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::int32_opt_field(eprosima::fastcdr::optional<int32_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1867,9 +1785,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::uint32_opt_field(uint32_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint32_tOpt) eprosima::fastcdr::optional<uint32_t>;
@@ -1883,7 +1798,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::uint32_opt_field(eprosima::fastcdr::optional<uint32_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1893,9 +1807,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::int64_opt_field(int64_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(int64_tOpt) eprosima::fastcdr::optional<int64_t>;
@@ -1909,7 +1820,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::int64_opt_field(eprosima::fastcdr::optional<int64_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1919,9 +1829,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::uint64_opt_field(uint64_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint64_tOpt) eprosima::fastcdr::optional<uint64_t>;
@@ -1935,7 +1842,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::uint64_opt_field(eprosima::fastcdr::optional<uint64_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1945,9 +1851,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::float_opt_field(float&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(floatOpt) eprosima::fastcdr::optional<float>;
@@ -1961,7 +1864,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::float_opt_field(eprosima::fastcdr::optional<float>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1971,9 +1873,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::double_opt_field(double&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(doubleOpt) eprosima::fastcdr::optional<double>;
@@ -1987,7 +1886,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::double_opt_field(eprosima::fastcdr::optional<double>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1997,9 +1895,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::bool_opt_field(bool&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(boolOpt) eprosima::fastcdr::optional<bool>;
@@ -2013,7 +1908,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::bool_opt_field(eprosima::fastcdr::optional<bool>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -2023,9 +1917,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::string_opt_field(std::string&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(stringOpt) eprosima::fastcdr::optional<std::string>;
@@ -2039,7 +1930,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::string_opt_field(eprosima::fastcdr::optional<std::string>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -2049,9 +1939,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::enum_opt_field(Color&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(ColorOpt) eprosima::fastcdr::optional<Color>;
@@ -2065,7 +1952,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::enum_opt_field(eprosima::fastcdr::optional<Color>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -2075,9 +1961,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::enum2_opt_field(Material&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(MaterialOpt) eprosima::fastcdr::optional<Material>;
@@ -2091,7 +1974,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::enum2_opt_field(eprosima::fastcdr::optional<Material>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -2101,9 +1983,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore KeyedCompleteTestType::struct_opt_field(StructType&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(StructTypeOpt) eprosima::fastcdr::optional<StructType>;
@@ -2117,7 +1996,6 @@ namespace swig {
   }
 }
 %ignore KeyedCompleteTestType::struct_opt_field(eprosima::fastcdr::optional<StructType>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used

--- a/fastdds_python/test/types/test_included_modules.i
+++ b/fastdds_python/test/types/test_included_modules.i
@@ -54,9 +54,7 @@
 %}
 
 %include <fastcdr/config.h>
-#if FASTCDR_VERSION_MAJOR > 1
 %import(module="fastdds") "fastcdr/xcdr/optional.hpp"
-#endif
 %import(module="fastdds") "fastdds/dds/core/LoanableCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableTypedCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableSequence.hpp"

--- a/fastdds_python/test/types/test_modules.i
+++ b/fastdds_python/test/types/test_modules.i
@@ -54,9 +54,7 @@
 %}
 
 %include <fastcdr/config.h>
-#if FASTCDR_VERSION_MAJOR > 1
 %import(module="fastdds") "fastcdr/xcdr/optional.hpp"
-#endif
 %import(module="fastdds") "fastdds/dds/core/LoanableCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableTypedCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableSequence.hpp"
@@ -431,9 +429,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::char_opt_field(char&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(charOpt) eprosima::fastcdr::optional<char>;
@@ -447,7 +442,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::char_opt_field(eprosima::fastcdr::optional<char>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -457,9 +451,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::uint8_opt_field(uint8_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint8_tOpt) eprosima::fastcdr::optional<uint8_t>;
@@ -473,7 +464,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::uint8_opt_field(eprosima::fastcdr::optional<uint8_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -483,9 +473,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::int16_opt_field(int16_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(int16_tOpt) eprosima::fastcdr::optional<int16_t>;
@@ -499,7 +486,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::int16_opt_field(eprosima::fastcdr::optional<int16_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -509,9 +495,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::uint16_opt_field(uint16_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint16_tOpt) eprosima::fastcdr::optional<uint16_t>;
@@ -525,7 +508,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::uint16_opt_field(eprosima::fastcdr::optional<uint16_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -535,9 +517,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::int32_opt_field(int32_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(int32_tOpt) eprosima::fastcdr::optional<int32_t>;
@@ -551,7 +530,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::int32_opt_field(eprosima::fastcdr::optional<int32_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -561,9 +539,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::uint32_opt_field(uint32_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint32_tOpt) eprosima::fastcdr::optional<uint32_t>;
@@ -577,7 +552,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::uint32_opt_field(eprosima::fastcdr::optional<uint32_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -587,9 +561,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::int64_opt_field(int64_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(int64_tOpt) eprosima::fastcdr::optional<int64_t>;
@@ -603,7 +574,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::int64_opt_field(eprosima::fastcdr::optional<int64_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -613,9 +583,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::uint64_opt_field(uint64_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint64_tOpt) eprosima::fastcdr::optional<uint64_t>;
@@ -629,7 +596,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::uint64_opt_field(eprosima::fastcdr::optional<uint64_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -639,9 +605,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::float_opt_field(float&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(floatOpt) eprosima::fastcdr::optional<float>;
@@ -655,7 +618,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::float_opt_field(eprosima::fastcdr::optional<float>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -665,9 +627,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::double_opt_field(double&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(doubleOpt) eprosima::fastcdr::optional<double>;
@@ -681,7 +640,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::double_opt_field(eprosima::fastcdr::optional<double>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -691,9 +649,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::bool_opt_field(bool&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(boolOpt) eprosima::fastcdr::optional<bool>;
@@ -707,7 +662,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::bool_opt_field(eprosima::fastcdr::optional<bool>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -717,9 +671,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::string_opt_field(std::string&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(stringOpt) eprosima::fastcdr::optional<std::string>;
@@ -733,7 +684,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::string_opt_field(eprosima::fastcdr::optional<std::string>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -743,9 +693,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::enum_opt_field(eprosima::test::Color&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(ColorOpt) eprosima::fastcdr::optional<eprosima::test::Color>;
@@ -759,7 +706,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::enum_opt_field(eprosima::fastcdr::optional<eprosima::test::Color>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -769,9 +715,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::enum2_opt_field(eprosima::test::Material&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(MaterialOpt) eprosima::fastcdr::optional<eprosima::test::Material>;
@@ -785,7 +728,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::enum2_opt_field(eprosima::fastcdr::optional<eprosima::test::Material>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -795,9 +737,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::CompleteTestType::struct_opt_field(eprosima::test::StructType&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(StructTypeOpt) eprosima::fastcdr::optional<eprosima::test::StructType>;
@@ -811,7 +750,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::CompleteTestType::struct_opt_field(eprosima::fastcdr::optional<eprosima::test::StructType>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1725,9 +1663,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::char_opt_field(char&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(charOpt) eprosima::fastcdr::optional<char>;
@@ -1741,7 +1676,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::char_opt_field(eprosima::fastcdr::optional<char>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1751,9 +1685,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::uint8_opt_field(uint8_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint8_tOpt) eprosima::fastcdr::optional<uint8_t>;
@@ -1767,7 +1698,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::uint8_opt_field(eprosima::fastcdr::optional<uint8_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1777,9 +1707,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::int16_opt_field(int16_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(int16_tOpt) eprosima::fastcdr::optional<int16_t>;
@@ -1793,7 +1720,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::int16_opt_field(eprosima::fastcdr::optional<int16_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1803,9 +1729,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::uint16_opt_field(uint16_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint16_tOpt) eprosima::fastcdr::optional<uint16_t>;
@@ -1819,7 +1742,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::uint16_opt_field(eprosima::fastcdr::optional<uint16_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1829,9 +1751,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::int32_opt_field(int32_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(int32_tOpt) eprosima::fastcdr::optional<int32_t>;
@@ -1845,7 +1764,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::int32_opt_field(eprosima::fastcdr::optional<int32_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1855,9 +1773,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::uint32_opt_field(uint32_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint32_tOpt) eprosima::fastcdr::optional<uint32_t>;
@@ -1871,7 +1786,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::uint32_opt_field(eprosima::fastcdr::optional<uint32_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1881,9 +1795,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::int64_opt_field(int64_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(int64_tOpt) eprosima::fastcdr::optional<int64_t>;
@@ -1897,7 +1808,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::int64_opt_field(eprosima::fastcdr::optional<int64_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1907,9 +1817,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::uint64_opt_field(uint64_t&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(uint64_tOpt) eprosima::fastcdr::optional<uint64_t>;
@@ -1923,7 +1830,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::uint64_opt_field(eprosima::fastcdr::optional<uint64_t>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1933,9 +1839,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::float_opt_field(float&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(floatOpt) eprosima::fastcdr::optional<float>;
@@ -1949,7 +1852,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::float_opt_field(eprosima::fastcdr::optional<float>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1959,9 +1861,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::double_opt_field(double&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(doubleOpt) eprosima::fastcdr::optional<double>;
@@ -1975,7 +1874,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::double_opt_field(eprosima::fastcdr::optional<double>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -1985,9 +1883,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::bool_opt_field(bool&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(boolOpt) eprosima::fastcdr::optional<bool>;
@@ -2001,7 +1896,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::bool_opt_field(eprosima::fastcdr::optional<bool>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -2011,9 +1905,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::string_opt_field(std::string&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(stringOpt) eprosima::fastcdr::optional<std::string>;
@@ -2027,7 +1918,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::string_opt_field(eprosima::fastcdr::optional<std::string>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -2037,9 +1927,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::enum_opt_field(eprosima::test::Color&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(ColorOpt) eprosima::fastcdr::optional<eprosima::test::Color>;
@@ -2053,7 +1940,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::enum_opt_field(eprosima::fastcdr::optional<eprosima::test::Color>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -2063,9 +1949,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::enum2_opt_field(eprosima::test::Material&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(MaterialOpt) eprosima::fastcdr::optional<eprosima::test::Material>;
@@ -2079,7 +1962,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::enum2_opt_field(eprosima::fastcdr::optional<eprosima::test::Material>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used
@@ -2089,9 +1971,6 @@ namespace swig {
 
 
 
-#if FASTCDR_VERSION_MAJOR == 1
-%ignore eprosima::test::KeyedCompleteTestType::struct_opt_field(eprosima::test::StructType&&);
-#else
 %ignore eprosima::fastcdr::optional::value;
 %ignore eprosima::fastcdr::optional::reset;
 %template(StructTypeOpt) eprosima::fastcdr::optional<eprosima::test::StructType>;
@@ -2105,7 +1984,6 @@ namespace swig {
   }
 }
 %ignore eprosima::test::KeyedCompleteTestType::struct_opt_field(eprosima::fastcdr::optional<eprosima::test::StructType>&&);
-#endif
 
 // Overloaded getter methods shadow each other and are equivalent in python
 // Const accesors produced constant enums instead of arrays/dictionaries when used

--- a/fastdds_python_examples/HelloWorldExample/HelloWorld.i
+++ b/fastdds_python_examples/HelloWorldExample/HelloWorld.i
@@ -54,9 +54,7 @@
 %}
 
 %include <fastcdr/config.h>
-#if FASTCDR_VERSION_MAJOR > 1
 %import(module="fastdds") "fastcdr/xcdr/optional.hpp"
-#endif
 %import(module="fastdds") "fastdds/dds/core/LoanableCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableTypedCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableSequence.hpp"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This is the Fast DDS Python counterpart of:

* eprosima/fast-dds#5073

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.4.x 1.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
