### PR TITLE
[21226] Add type support regeneration utility to 1.2.x

### DIFF
--- a/fastdds_python_examples/HelloWorldExample/CMakeLists.txt
+++ b/fastdds_python_examples/HelloWorldExample/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.16.3)
 
 # SWIG: use standard target name.
 if(POLICY CMP0078)

--- a/fastdds_python_examples/HelloWorldExample/CMakeLists.txt
+++ b/fastdds_python_examples/HelloWorldExample/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.22)
 
 # SWIG: use standard target name.
 if(POLICY CMP0078)

--- a/utils/scripts/update_generated_code_from_idl.sh
+++ b/utils/scripts/update_generated_code_from_idl.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+idl_files=(
+    './fastdds_python/test/types/test_modules.idl'
+    './fastdds_python/test/types/test_complete.idl'
+    './fastdds_python/test/types/test_included_modules.idl'
+    './fastdds_python_examples/HelloWorldExample/HelloWorld.idl'
+)
+
+red='\E[1;31m'
+yellow='\E[1;33m'
+textreset='\E[1;0m'
+
+current_dir=$(git rev-parse --show-toplevel)
+
+if [[ ! "$(pwd -P)" -ef "${current_dir}" ]]; then
+    echo -e "${red}This script must be executed in the repository root directory.${textreset}"
+    exit -1
+fi
+
+if [[ -z "$(which fastddsgen)" ]]; then
+    echo "Cannot find fastddsgen. Please, include it in PATH environment variable"
+    exit -1
+fi
+
+ret_value=0
+
+for idl_file in "${idl_files[@]}"; do
+    idl_dir=$(dirname "${idl_file}")
+    file_from_gen=$(basename "${idl_file}")
+
+    echo -e "Processing ${yellow}${idl_file}${textreset}"
+
+    cd "${idl_dir}"
+
+    echo "Running: fastddsgen -cdr both -replace -flat-output-dir -python ${file_from_gen}"
+    fastddsgen -cdr both -replace -flat-output-dir -python ${file_from_gen}
+
+    if [[ $? != 0 ]]; then
+        ret_value=-1
+    fi
+
+    cd -
+done
+
+exit ${ret_value}

--- a/utils/scripts/update_generated_code_from_idl.sh
+++ b/utils/scripts/update_generated_code_from_idl.sh
@@ -19,9 +19,9 @@ fi
 ret_value=0
 
 cd ./fastdds_python/test/types
-echo -e "Processing ${yellow}test_complete.idl test_modules.idl${textreset}"
-echo "Running: fastddsgen -cdr both -replace -python test_complete.idl test_modules.idl"
-fastddsgen -cdr both -replace -python test_complete.idl test_modules.idl
+echo -e "Processing ${yellow}test_complete.idl${textreset}"
+echo "Running: fastddsgen -replace -python test_complete.idl"
+fastddsgen -replace -python test_complete.idl
 if [[ $? != 0 ]]; then
     ret_value=-1
 fi
@@ -31,8 +31,8 @@ if [[ $ret_value != -1 ]]; then
     cd "./fastdds_python_examples/HelloWorldExample"
 
 echo -e "Processing ${yellow}HelloWorld.idl${textreset}"
-    echo "Running: fastddsgen -cdr both -replace -python HelloWorld.idl"
-    fastddsgen -cdr both -replace -python HelloWorld.idl
+    echo "Running: fastddsgen -replace -python HelloWorld.idl"
+    fastddsgen -replace -python HelloWorld.idl
 fi
 
 if [[ $? != 0 ]]; then

--- a/utils/scripts/update_generated_code_from_idl.sh
+++ b/utils/scripts/update_generated_code_from_idl.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-idl_files=(
-    './fastdds_python/test/types/test_modules.idl'
-    './fastdds_python/test/types/test_complete.idl'
-    './fastdds_python/test/types/test_included_modules.idl'
-    './fastdds_python_examples/HelloWorldExample/HelloWorld.idl'
-)
-
 red='\E[1;31m'
 yellow='\E[1;33m'
 textreset='\E[1;0m'
@@ -25,22 +18,26 @@ fi
 
 ret_value=0
 
-for idl_file in "${idl_files[@]}"; do
-    idl_dir=$(dirname "${idl_file}")
-    file_from_gen=$(basename "${idl_file}")
+cd ./fastdds_python/test/types
+echo -e "Processing ${yellow}test_complete.idl test_modules.idl${textreset}"
+echo "Running: fastddsgen -cdr both -replace -python test_complete.idl test_modules.idl"
+fastddsgen -cdr both -replace -python test_complete.idl test_modules.idl
+if [[ $? != 0 ]]; then
+    ret_value=-1
+fi
+cd -
 
-    echo -e "Processing ${yellow}${idl_file}${textreset}"
+if [[ $ret_value != -1 ]]; then
+    cd "./fastdds_python_examples/HelloWorldExample"
 
-    cd "${idl_dir}"
+echo -e "Processing ${yellow}HelloWorld.idl${textreset}"
+    echo "Running: fastddsgen -cdr both -replace -python HelloWorld.idl"
+    fastddsgen -cdr both -replace -python HelloWorld.idl
+fi
 
-    echo "Running: fastddsgen -cdr both -replace -flat-output-dir -python ${file_from_gen}"
-    fastddsgen -cdr both -replace -flat-output-dir -python ${file_from_gen}
-
-    if [[ $? != 0 ]]; then
-        ret_value=-1
-    fi
-
-    cd -
-done
+if [[ $? != 0 ]]; then
+    ret_value=-1
+fi
+cd -
 
 exit ${ret_value}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR cherry-picks a set of commits that created and updated the type support regeneration utility to bring it to the version 1.2.x.
(Tested locally)
Related PR:
- https://github.com/eProsima/Fast-DDS-Gen/pull/368
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.4.x 1.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
