### PR TITLE
[21310] Remove 2.13.x from CI in 1.4.x version

### DIFF
--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -52,24 +52,18 @@ concurrency:
 
 jobs:
   ubuntu-ci:
-    strategy:
-      fail-fast: false
-      matrix:
-        fastdds-branch:
-          - '2.14.x'
-          - '2.13.x'
     if: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'conflicts') }}
     uses: ./.github/workflows/reusable-ubuntu-ci.yml
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
       # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
       os-version: ${{ inputs.os-version || 'ubuntu-22.04' }}
-      label: 'ubuntu-ci-1.4.x-${{ matrix.fastdds-branch }}'
+      label: 'ubuntu-ci-1.4.x'
       colcon-args: ${{ inputs.colcon-args }}
       cmake-args: ${{ inputs.cmake-args }}
       ctest-args: ${{ inputs.ctest-args }}
       fastdds-python-branch: ${{ inputs.fastdds-python-branch || github.ref }}
-      fastdds-branch: ${{ inputs.fastdds-branch || matrix.fastdds-branch }}
+      fastdds-branch: ${{ inputs.fastdds-branch || '2.14.x' }}
       run-build: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
       run-tests: ${{ (inputs.run-tests == true) || ((github.event_name == 'pull_request') && (!contains(github.event.pull_request.labels.*.name, 'no-test'))) }}
       use-ccache: ${{ inputs.use-ccache || false }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -59,9 +59,6 @@ jobs:
         vs-toolset:
           - 'v141'
           - 'v142'
-        fastdds-branch:
-          - '2.14.x'
-          - '2.13.x'
     if: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'conflicts') }}
     uses: ./.github/workflows/reusable-windows-ci.yml
     with:
@@ -69,11 +66,11 @@ jobs:
       # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
       os-version: ${{ inputs.os-version || 'windows-2019' }}
       vs-toolset: ${{ inputs.vs-toolset || matrix.vs-toolset }}
-      label: 'windows-${{ matrix.vs-toolset }}-ci-1.4.x-${{ matrix.fastdds-branch }}'
+      label: 'windows-${{ matrix.vs-toolset }}-ci-1.4.x'
       colcon-args: ${{ inputs.colcon-args }}
       cmake-args: ${{ inputs.cmake-args }}
       ctest-args: ${{ inputs.ctest-args }}
       fastdds-python-branch: ${{ inputs.fastdds-python-branch || github.ref }}
-      fastdds-branch: ${{ inputs.fastdds-branch || matrix.fastdds-branch }}
+      fastdds-branch: ${{ inputs.fastdds-branch || '2.14.x' }}
       run-build: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
       run-tests: ${{ (inputs.run-tests == true) || ((github.event_name == 'pull_request') && (!contains(github.event.pull_request.labels.*.name, 'no-test'))) }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Fast DDS version 2.13.x is EOL. In this PR
- #162

It was removed from nightly jobs but the changes performed in this PR was missing in 1.4.x (removing testing with 2.13.x)
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.4.x 1.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
