### PR TITLE
[21486] Fix HelloWorld example with TopicDataType refactored code

### DIFF
--- a/fastdds_python_examples/HelloWorldExample/HelloWorldExample.py
+++ b/fastdds_python_examples/HelloWorldExample/HelloWorldExample.py
@@ -70,13 +70,13 @@ class Reader():
     self.participant = factory.create_participant(domain, self.participant_qos)
 
     self.topic_data_type = HelloWorld.HelloWorldPubSubType()
-    self.topic_data_type.setName("HelloWorldDataType")
+    self.topic_data_type.set_name("HelloWorldDataType")
     self.type_support = fastdds.TypeSupport(self.topic_data_type)
     self.participant.register_type(self.type_support)
 
     self.topic_qos = fastdds.TopicQos()
     self.participant.get_default_topic_qos(self.topic_qos)
-    self.topic = self.participant.create_topic("myTopic", self.topic_data_type.getName(), self.topic_qos)
+    self.topic = self.participant.create_topic("myTopic", self.topic_data_type.get_name(), self.topic_qos)
 
     self.subscriber_qos = fastdds.SubscriberQos()
     self.participant.get_default_subscriber_qos(self.subscriber_qos)
@@ -110,13 +110,13 @@ class Writer:
     self.participant = factory.create_participant(domain, self.participant_qos)
 
     self.topic_data_type = HelloWorld.HelloWorldPubSubType()
-    self.topic_data_type.setName("HelloWorldDataType")
+    self.topic_data_type.set_name("HelloWorldDataType")
     self.type_support = fastdds.TypeSupport(self.topic_data_type)
     self.participant.register_type(self.type_support)
 
     self.topic_qos = fastdds.TopicQos()
     self.participant.get_default_topic_qos(self.topic_qos)
-    self.topic = self.participant.create_topic("myTopic", self.topic_data_type.getName(), self.topic_qos)
+    self.topic = self.participant.create_topic("myTopic", self.topic_data_type.get_name(), self.topic_qos)
 
     self.publisher_qos = fastdds.PublisherQos()
     self.participant.get_default_publisher_qos(self.publisher_qos)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
When updating the Fast DDS python code to the new TopicDataType methods, the HelloWorld example update was missed. This PR updates changes those calls to use the new API.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.4.x 1.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #182 

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- ❌: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
    - We will update the CI so it runs the example in a follow-up
- ❌: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
