### PR TITLE
[21783] Regenerate project types with Fast DDS-Gen v4.0.2

### DIFF
--- a/fastdds_python/test/types/test_completeTypeObjectSupport.cxx
+++ b/fastdds_python/test/types/test_completeTypeObjectSupport.cxx
@@ -1862,7 +1862,7 @@ void register_CompleteTestType_type_identifier(
             ReturnCode_t return_code_array_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_array_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_3", type_ids_array_uint8_field);
+                "anonymous_array_byte_3", type_ids_array_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_array_uint8_field)
             {
@@ -1876,31 +1876,31 @@ void register_CompleteTestType_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_3_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_3 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_array_uint8_field, element_identifier_anonymous_array_uint8_t_3_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_3_ec)
+                bool element_identifier_anonymous_array_byte_3_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_3 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_array_uint8_field, element_identifier_anonymous_array_byte_3_ec))};
+                if (!element_identifier_anonymous_array_byte_3_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_3 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_3 = EK_COMPLETE;
                 if (TK_NONE == type_ids_array_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_3 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_3 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_3 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_3 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_3, element_flags_anonymous_array_uint8_t_3);
+                CollectionElementFlag element_flags_anonymous_array_byte_3 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_3 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_3, element_flags_anonymous_array_byte_3);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(3));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_3, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_3));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_3, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_3));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_3", type_ids_array_uint8_field))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_3", type_ids_array_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_3 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_3 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -2750,7 +2750,7 @@ void register_CompleteTestType_type_identifier(
             ReturnCode_t return_code_bounded_sequence_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_bounded_sequence_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_5", type_ids_bounded_sequence_uint8_field);
+                "anonymous_sequence_byte_5", type_ids_bounded_sequence_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_bounded_sequence_uint8_field)
             {
@@ -2764,29 +2764,29 @@ void register_CompleteTestType_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_5_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_5 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_bounded_sequence_uint8_field, element_identifier_anonymous_sequence_uint8_t_5_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_5_ec)
+                bool element_identifier_anonymous_sequence_byte_5_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_5 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_bounded_sequence_uint8_field, element_identifier_anonymous_sequence_byte_5_ec))};
+                if (!element_identifier_anonymous_sequence_byte_5_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_5 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_5 = EK_COMPLETE;
                 if (TK_NONE == type_ids_bounded_sequence_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_5 = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_5 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_5 = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_5 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_5, element_flags_anonymous_sequence_uint8_t_5);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_5 = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_5 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_5, element_flags_anonymous_sequence_byte_5);
                 {
                     SBound bound = static_cast<SBound>(5);
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_5, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_5));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_5, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_5));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_5", type_ids_bounded_sequence_uint8_field))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_5", type_ids_bounded_sequence_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_5 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_5 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -3612,7 +3612,7 @@ void register_CompleteTestType_type_identifier(
             ReturnCode_t return_code_unbounded_sequence_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_unbounded_sequence_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_unbounded_sequence_uint8_field);
+                "anonymous_sequence_byte_unbounded", type_ids_unbounded_sequence_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_unbounded_sequence_uint8_field)
             {
@@ -3626,29 +3626,29 @@ void register_CompleteTestType_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_unbounded_sequence_uint8_field, element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_unbounded_sequence_uint8_field, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_unbounded_sequence_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded, element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_unbounded", type_ids_unbounded_sequence_uint8_field))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_unbounded_sequence_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -5647,7 +5647,7 @@ void register_KeyedCompleteTestType_type_identifier(
             ReturnCode_t return_code_array_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_array_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_3", type_ids_array_uint8_field);
+                "anonymous_array_byte_3", type_ids_array_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_array_uint8_field)
             {
@@ -5661,31 +5661,31 @@ void register_KeyedCompleteTestType_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_3_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_3 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_array_uint8_field, element_identifier_anonymous_array_uint8_t_3_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_3_ec)
+                bool element_identifier_anonymous_array_byte_3_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_3 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_array_uint8_field, element_identifier_anonymous_array_byte_3_ec))};
+                if (!element_identifier_anonymous_array_byte_3_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_3 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_3 = EK_COMPLETE;
                 if (TK_NONE == type_ids_array_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_3 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_3 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_3 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_3 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_3, element_flags_anonymous_array_uint8_t_3);
+                CollectionElementFlag element_flags_anonymous_array_byte_3 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_3 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_3, element_flags_anonymous_array_byte_3);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(3));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_3, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_3));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_3, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_3));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_3", type_ids_array_uint8_field))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_3", type_ids_array_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_3 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_3 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -6535,7 +6535,7 @@ void register_KeyedCompleteTestType_type_identifier(
             ReturnCode_t return_code_bounded_sequence_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_bounded_sequence_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_5", type_ids_bounded_sequence_uint8_field);
+                "anonymous_sequence_byte_5", type_ids_bounded_sequence_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_bounded_sequence_uint8_field)
             {
@@ -6549,29 +6549,29 @@ void register_KeyedCompleteTestType_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_5_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_5 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_bounded_sequence_uint8_field, element_identifier_anonymous_sequence_uint8_t_5_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_5_ec)
+                bool element_identifier_anonymous_sequence_byte_5_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_5 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_bounded_sequence_uint8_field, element_identifier_anonymous_sequence_byte_5_ec))};
+                if (!element_identifier_anonymous_sequence_byte_5_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_5 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_5 = EK_COMPLETE;
                 if (TK_NONE == type_ids_bounded_sequence_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_5 = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_5 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_5 = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_5 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_5, element_flags_anonymous_sequence_uint8_t_5);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_5 = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_5 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_5, element_flags_anonymous_sequence_byte_5);
                 {
                     SBound bound = static_cast<SBound>(5);
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_5, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_5));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_5, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_5));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_5", type_ids_bounded_sequence_uint8_field))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_5", type_ids_bounded_sequence_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_5 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_5 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -7397,7 +7397,7 @@ void register_KeyedCompleteTestType_type_identifier(
             ReturnCode_t return_code_unbounded_sequence_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_unbounded_sequence_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_unbounded_sequence_uint8_field);
+                "anonymous_sequence_byte_unbounded", type_ids_unbounded_sequence_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_unbounded_sequence_uint8_field)
             {
@@ -7411,29 +7411,29 @@ void register_KeyedCompleteTestType_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_unbounded_sequence_uint8_field, element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_unbounded_sequence_uint8_field, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_unbounded_sequence_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded, element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_unbounded", type_ids_unbounded_sequence_uint8_field))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_unbounded_sequence_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }

--- a/fastdds_python/test/types/test_modulesTypeObjectSupport.cxx
+++ b/fastdds_python/test/types/test_modulesTypeObjectSupport.cxx
@@ -1835,7 +1835,7 @@ void register_CompleteTestType_type_identifier(
             ReturnCode_t return_code_array_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_array_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_3", type_ids_array_uint8_field);
+                "anonymous_array_byte_3", type_ids_array_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_array_uint8_field)
             {
@@ -1849,31 +1849,31 @@ void register_CompleteTestType_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_3_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_3 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_array_uint8_field, element_identifier_anonymous_array_uint8_t_3_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_3_ec)
+                bool element_identifier_anonymous_array_byte_3_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_3 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_array_uint8_field, element_identifier_anonymous_array_byte_3_ec))};
+                if (!element_identifier_anonymous_array_byte_3_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_3 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_3 = EK_COMPLETE;
                 if (TK_NONE == type_ids_array_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_3 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_3 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_3 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_3 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_3, element_flags_anonymous_array_uint8_t_3);
+                CollectionElementFlag element_flags_anonymous_array_byte_3 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_3 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_3, element_flags_anonymous_array_byte_3);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(3));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_3, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_3));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_3, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_3));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_3", type_ids_array_uint8_field))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_3", type_ids_array_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_3 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_3 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -2723,7 +2723,7 @@ void register_CompleteTestType_type_identifier(
             ReturnCode_t return_code_bounded_sequence_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_bounded_sequence_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_5", type_ids_bounded_sequence_uint8_field);
+                "anonymous_sequence_byte_5", type_ids_bounded_sequence_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_bounded_sequence_uint8_field)
             {
@@ -2737,29 +2737,29 @@ void register_CompleteTestType_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_5_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_5 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_bounded_sequence_uint8_field, element_identifier_anonymous_sequence_uint8_t_5_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_5_ec)
+                bool element_identifier_anonymous_sequence_byte_5_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_5 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_bounded_sequence_uint8_field, element_identifier_anonymous_sequence_byte_5_ec))};
+                if (!element_identifier_anonymous_sequence_byte_5_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_5 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_5 = EK_COMPLETE;
                 if (TK_NONE == type_ids_bounded_sequence_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_5 = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_5 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_5 = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_5 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_5, element_flags_anonymous_sequence_uint8_t_5);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_5 = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_5 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_5, element_flags_anonymous_sequence_byte_5);
                 {
                     SBound bound = static_cast<SBound>(5);
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_5, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_5));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_5, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_5));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_5", type_ids_bounded_sequence_uint8_field))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_5", type_ids_bounded_sequence_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_5 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_5 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -3585,7 +3585,7 @@ void register_CompleteTestType_type_identifier(
             ReturnCode_t return_code_unbounded_sequence_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_unbounded_sequence_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_unbounded_sequence_uint8_field);
+                "anonymous_sequence_byte_unbounded", type_ids_unbounded_sequence_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_unbounded_sequence_uint8_field)
             {
@@ -3599,29 +3599,29 @@ void register_CompleteTestType_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_unbounded_sequence_uint8_field, element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_unbounded_sequence_uint8_field, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_unbounded_sequence_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded, element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_unbounded", type_ids_unbounded_sequence_uint8_field))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_unbounded_sequence_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -5620,7 +5620,7 @@ void register_KeyedCompleteTestType_type_identifier(
             ReturnCode_t return_code_array_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_array_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_3", type_ids_array_uint8_field);
+                "anonymous_array_byte_3", type_ids_array_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_array_uint8_field)
             {
@@ -5634,31 +5634,31 @@ void register_KeyedCompleteTestType_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_3_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_3 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_array_uint8_field, element_identifier_anonymous_array_uint8_t_3_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_3_ec)
+                bool element_identifier_anonymous_array_byte_3_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_3 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_array_uint8_field, element_identifier_anonymous_array_byte_3_ec))};
+                if (!element_identifier_anonymous_array_byte_3_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_3 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_3 = EK_COMPLETE;
                 if (TK_NONE == type_ids_array_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_3 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_3 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_3 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_3 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_3, element_flags_anonymous_array_uint8_t_3);
+                CollectionElementFlag element_flags_anonymous_array_byte_3 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_3 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_3, element_flags_anonymous_array_byte_3);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(3));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_3, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_3));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_3, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_3));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_3", type_ids_array_uint8_field))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_3", type_ids_array_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_3 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_3 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -6508,7 +6508,7 @@ void register_KeyedCompleteTestType_type_identifier(
             ReturnCode_t return_code_bounded_sequence_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_bounded_sequence_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_5", type_ids_bounded_sequence_uint8_field);
+                "anonymous_sequence_byte_5", type_ids_bounded_sequence_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_bounded_sequence_uint8_field)
             {
@@ -6522,29 +6522,29 @@ void register_KeyedCompleteTestType_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_5_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_5 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_bounded_sequence_uint8_field, element_identifier_anonymous_sequence_uint8_t_5_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_5_ec)
+                bool element_identifier_anonymous_sequence_byte_5_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_5 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_bounded_sequence_uint8_field, element_identifier_anonymous_sequence_byte_5_ec))};
+                if (!element_identifier_anonymous_sequence_byte_5_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_5 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_5 = EK_COMPLETE;
                 if (TK_NONE == type_ids_bounded_sequence_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_5 = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_5 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_5 = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_5 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_5, element_flags_anonymous_sequence_uint8_t_5);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_5 = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_5 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_5, element_flags_anonymous_sequence_byte_5);
                 {
                     SBound bound = static_cast<SBound>(5);
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_5, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_5));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_5, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_5));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_5", type_ids_bounded_sequence_uint8_field))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_5", type_ids_bounded_sequence_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_5 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_5 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -7370,7 +7370,7 @@ void register_KeyedCompleteTestType_type_identifier(
             ReturnCode_t return_code_unbounded_sequence_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_unbounded_sequence_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_unbounded_sequence_uint8_field);
+                "anonymous_sequence_byte_unbounded", type_ids_unbounded_sequence_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_unbounded_sequence_uint8_field)
             {
@@ -7384,29 +7384,29 @@ void register_KeyedCompleteTestType_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_unbounded_sequence_uint8_field, element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_unbounded_sequence_uint8_field, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_unbounded_sequence_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded, element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_unbounded", type_ids_unbounded_sequence_uint8_field))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_unbounded_sequence_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR regenerate project types using latest Fast DDS-Gen v4.0.2

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.4.x 1.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- **NA** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **NA** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
