### PR TITLE
[21808] Update DataWriter/Reader `get_matched_publication/subscription...()` (2.x) API tests

### DIFF
--- a/fastdds_python/test/api/test_datareader.py
+++ b/fastdds_python/test/api/test_datareader.py
@@ -802,6 +802,7 @@ def test_get_matched_publications(datareader, datawriter):
     # The datawriter (added in the fixture) is the only
     # one that should be matched
     assert(1 == ihs.size())
+    assert(ihs[0] == datawriter.get_instance_handle())
 
 
 def test_get_requested_deadline_missed_status(datareader):

--- a/fastdds_python/test/api/test_datareader.py
+++ b/fastdds_python/test/api/test_datareader.py
@@ -780,7 +780,7 @@ def test_get_matched_publication_data(datareader):
     """
     pub_data = fastdds.PublicationBuiltinTopicData()
     ih = fastdds.InstanceHandle_t()
-    assert(fastdds.RETCODE_UNSUPPORTED ==
+    assert(fastdds.RETCODE_BAD_PARAMETER ==
            datareader.get_matched_publication_data(pub_data, ih))
 
 
@@ -790,7 +790,7 @@ def test_get_matched_publications(datareader):
     - DataReader::get_matched_publications
     """
     ihs = fastdds.InstanceHandleVector()
-    assert(fastdds.RETCODE_UNSUPPORTED ==
+    assert(fastdds.RETCODE_OK ==
            datareader.get_matched_publications(ihs))
 
 

--- a/fastdds_python/test/api/test_datareader.py
+++ b/fastdds_python/test/api/test_datareader.py
@@ -773,25 +773,35 @@ def test_get_liveliness_changed_status(datareader):
     assert(fastdds.c_InstanceHandle_Unknown == status.last_publication_handle)
 
 
-def test_get_matched_publication_data(datareader):
+def test_get_matched_publication_data(datareader, datawriter):
     """
     This test checks:
     - DataReader::get_matched_publication_data
     """
+    # Check with an invalid instance handle
     pub_data = fastdds.PublicationBuiltinTopicData()
     ih = fastdds.InstanceHandle_t()
     assert(fastdds.RETCODE_BAD_PARAMETER ==
            datareader.get_matched_publication_data(pub_data, ih))
 
+    time.sleep(1)
+    # Check with the writer's instance handle
+    assert(fastdds.RETCODE_OK ==
+           datareader.get_matched_publication_data(pub_data, datawriter.get_instance_handle()))
+    assert(pub_data.guid == datawriter.guid())
 
-def test_get_matched_publications(datareader):
+def test_get_matched_publications(datareader, datawriter):
     """
     This test checks:
     - DataReader::get_matched_publications
     """
     ihs = fastdds.InstanceHandleVector()
+    time.sleep(1)
     assert(fastdds.RETCODE_OK ==
            datareader.get_matched_publications(ihs))
+    # The datawriter (added in the fixture) is the only
+    # one that should be matched
+    assert(1 == ihs.size())
 
 
 def test_get_requested_deadline_missed_status(datareader):

--- a/fastdds_python/test/api/test_datawriter.py
+++ b/fastdds_python/test/api/test_datawriter.py
@@ -308,26 +308,40 @@ def test_get_liveliness_lost_status(datawriter):
     assert(0 == status.total_count_change)
 
 
-def test_get_matched_subscription_data(datawriter):
+def test_get_matched_subscription_data(datawriter, reader_topic, subscriber):
     """
     This test checks:
     - DataWriter::get_matched_subscription_data
     """
+    # Check with an invalid instance handle
     sub_data = fastdds.SubscriptionBuiltinTopicData()
     ih = fastdds.InstanceHandle_t()
     assert(fastdds.RETCODE_BAD_PARAMETER ==
            datawriter.get_matched_subscription_data(sub_data, ih))
 
+    # Add a reader and check that the datawriter has matched subscriptions
+    datareader = subscriber.create_datareader(reader_topic, fastdds.DATAREADER_QOS_DEFAULT)
+    time.sleep(1)
+    assert(fastdds.RETCODE_OK ==
+           datawriter.get_matched_subscription_data(sub_data, datareader.get_instance_handle()))
+    assert(sub_data.guid == datareader.guid())
+    assert(fastdds.RETCODE_OK ==
+           subscriber.delete_datareader(datareader))
 
-def test_get_matched_subscriptions(datawriter):
+def test_get_matched_subscriptions(datawriter, reader_topic, subscriber):
     """
     This test checks:
     - DataWriter::get_matched_subscriptions
     """
     ihs = fastdds.InstanceHandleVector()
+    # Add a reader and check that the datawriter has matched subscriptions
+    datareader = subscriber.create_datareader(reader_topic, fastdds.DATAREADER_QOS_DEFAULT)
+    time.sleep(1)
+    assert(fastdds.RETCODE_OK == datawriter.get_matched_subscriptions(ihs))
+    assert(1 == ihs.size())
+    assert(ihs[0] == datareader.get_instance_handle())
     assert(fastdds.RETCODE_OK ==
-           datawriter.get_matched_subscriptions(ihs))
-
+           subscriber.delete_datareader(datareader))
 
 def test_get_offered_deadline_missed_status(datawriter):
     """

--- a/fastdds_python/test/api/test_datawriter.py
+++ b/fastdds_python/test/api/test_datawriter.py
@@ -315,7 +315,7 @@ def test_get_matched_subscription_data(datawriter):
     """
     sub_data = fastdds.SubscriptionBuiltinTopicData()
     ih = fastdds.InstanceHandle_t()
-    assert(fastdds.RETCODE_UNSUPPORTED ==
+    assert(fastdds.RETCODE_BAD_PARAMETER ==
            datawriter.get_matched_subscription_data(sub_data, ih))
 
 
@@ -325,7 +325,7 @@ def test_get_matched_subscriptions(datawriter):
     - DataWriter::get_matched_subscriptions
     """
     ihs = fastdds.InstanceHandleVector()
-    assert(fastdds.RETCODE_UNSUPPORTED ==
+    assert(fastdds.RETCODE_OK ==
            datawriter.get_matched_subscriptions(ihs))
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR updates DataWriter/Reader `get_matched_publication/subscirption...()` tests in the `Fast DDS Python 2.x branch` as result of API implementation:

* eProsima/Fast-DDS#5312

**IMPORTANT**
This PR must be merged after 
* #193 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 1.4.x 1.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
