### PR TITLE
Add support for `string_255` type and fix discovery status memory leaks

### DIFF
--- a/fastdds_python/src/swig/fastcdr/cdr/fixed_size_string.i
+++ b/fastdds_python/src/swig/fastcdr/cdr/fixed_size_string.i
@@ -20,3 +20,6 @@
 %ignore eprosima::fastcdr::fixed_string::operator const char*() const;
 
 %include "fastcdr/cdr/fixed_size_string.hpp"
+
+// Define string_255 as a fixed_string<255>
+%template(string_255) eprosima::fastcdr::fixed_string<255>;

--- a/fastdds_python/src/swig/fastdds.i
+++ b/fastdds_python/src/swig/fastdds.i
@@ -168,6 +168,9 @@ namespace xtypes {
 %include "fastdds/rtps/common/SampleIdentity.i"
 %include "fastdds/rtps/common/WriteParams.i"
 %include "fastdds/rtps/builtin/data/ContentFilterProperty.i"
+%include "fastdds/rtps/reader/ReaderDiscoveryInfo.i"
+%include "fastdds/rtps/writer/WriterDiscoveryInfo.i"
+%include "fastdds/rtps/participant/ParticipantDiscoveryInfo.i"
 
 %include "fastdds/dds/common/InstanceHandle.i"
 %include "fastdds/dds/core/ReturnCode.i"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR add support for using `string_255` type in python applicatioons. 

It also fixes the following warnings get when participant listener functions are called:

```bash
swig/python detected a memory leak of type 'eprosima::fastdds::rtps::ParticipantDiscoveryStatus *', no destructor found.
swig/python detected a memory leak of type 'eprosima::fastdds::rtps::WriterDiscoveryStatus *', no destructor found.
swig/python detected a memory leak of type 'eprosima::fastdds::rtps::ReaderDiscoveryStatus *', no destructor found.
```

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.1.x 2.0.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
