### PR TITLE
[22858] Update types with Fast DDS Gen 4.0.4 (2.1.x)

### DIFF
--- a/fastdds_python/test/types/test_complete.i
+++ b/fastdds_python/test/types/test_complete.i
@@ -56,6 +56,7 @@
 
 %include <fastcdr/config.h>
 %import(module="fastdds") "fastcdr/xcdr/optional.hpp"
+%import(module="fastdds") "fastcdr/cdr/fixed_size_string.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableTypedCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableSequence.hpp"
@@ -263,8 +264,6 @@ namespace swig {
         return (*self)[i];
     }
 }
-
-
 
 ////////////////////////////////////////////////////////
 // Binding for class CompleteTestType

--- a/fastdds_python/test/types/test_completeCdrAux.hpp
+++ b/fastdds_python/test/types/test_completeCdrAux.hpp
@@ -49,8 +49,6 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructType& data);
 
-
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const CompleteTestType& data);

--- a/fastdds_python/test/types/test_completeCdrAux.ipp
+++ b/fastdds_python/test/types/test_completeCdrAux.ipp
@@ -257,8 +257,6 @@ void serialize_key(
 }
 
 
-
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,

--- a/fastdds_python/test/types/test_completePubSubTypes.cxx
+++ b/fastdds_python/test/types/test_completePubSubTypes.cxx
@@ -76,6 +76,7 @@ bool StructTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -212,8 +213,6 @@ void StructTypePubSubType::register_type_object_representation()
     register_StructType_type_identifier(type_identifiers_);
 }
 
-
-
 CompleteTestTypePubSubType::CompleteTestTypePubSubType()
 {
     set_name("CompleteTestType");
@@ -259,6 +258,7 @@ bool CompleteTestTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -440,6 +440,7 @@ bool KeyedCompleteTestTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/fastdds_python/test/types/test_completePubSubTypes.hpp
+++ b/fastdds_python/test/types/test_completePubSubTypes.hpp
@@ -120,8 +120,6 @@ private:
 
 };
 
-
-
 /*!
  * @brief This class represents the TopicDataType of the type CompleteTestType defined by the user in the IDL file.
  * @ingroup test_complete

--- a/fastdds_python/test/types/test_included_modules.i
+++ b/fastdds_python/test/types/test_included_modules.i
@@ -54,7 +54,7 @@
 %}
 
 %include <fastcdr/config.h>
-%import(module="fastdds") "fastcdr/xcdr/optional.hpp"
+%import(module="fastdds") "fastcdr/cdr/fixed_size_string.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableTypedCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableSequence.hpp"

--- a/fastdds_python/test/types/test_included_modulesPubSubTypes.cxx
+++ b/fastdds_python/test/types/test_included_modulesPubSubTypes.cxx
@@ -78,6 +78,7 @@ namespace eprosima {
                 ser.serialize_encapsulation();
                 // Serialize the object.
                 ser << *p_type;
+                ser.set_dds_cdr_options({0,0});
             }
             catch (eprosima::fastcdr::exception::Exception& /*exception*/)
             {

--- a/fastdds_python/test/types/test_modules.i
+++ b/fastdds_python/test/types/test_modules.i
@@ -55,6 +55,7 @@
 
 %include <fastcdr/config.h>
 %import(module="fastdds") "fastcdr/xcdr/optional.hpp"
+%import(module="fastdds") "fastcdr/cdr/fixed_size_string.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableTypedCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableSequence.hpp"
@@ -251,8 +252,6 @@ namespace swig {
         return (*self)[i];
     }
 }
-
-
 
 ////////////////////////////////////////////////////////
 // Binding for class eprosima::test::CompleteTestType

--- a/fastdds_python/test/types/test_modulesCdrAux.hpp
+++ b/fastdds_python/test/types/test_modulesCdrAux.hpp
@@ -45,8 +45,6 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::test::StructType& data);
 
-
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::test::CompleteTestType& data);

--- a/fastdds_python/test/types/test_modulesCdrAux.ipp
+++ b/fastdds_python/test/types/test_modulesCdrAux.ipp
@@ -250,8 +250,6 @@ void serialize_key(
 }
 
 
-
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,

--- a/fastdds_python/test/types/test_modulesPubSubTypes.cxx
+++ b/fastdds_python/test/types/test_modulesPubSubTypes.cxx
@@ -78,6 +78,7 @@ namespace eprosima {
                 ser.serialize_encapsulation();
                 // Serialize the object.
                 ser << *p_type;
+                ser.set_dds_cdr_options({0,0});
             }
             catch (eprosima::fastcdr::exception::Exception& /*exception*/)
             {
@@ -214,8 +215,6 @@ namespace eprosima {
             register_StructType_type_identifier(type_identifiers_);
         }
 
-
-
         CompleteTestTypePubSubType::CompleteTestTypePubSubType()
         {
             set_name("eprosima::test::CompleteTestType");
@@ -261,6 +260,7 @@ namespace eprosima {
                 ser.serialize_encapsulation();
                 // Serialize the object.
                 ser << *p_type;
+                ser.set_dds_cdr_options({0,0});
             }
             catch (eprosima::fastcdr::exception::Exception& /*exception*/)
             {
@@ -442,6 +442,7 @@ namespace eprosima {
                 ser.serialize_encapsulation();
                 // Serialize the object.
                 ser << *p_type;
+                ser.set_dds_cdr_options({0,0});
             }
             catch (eprosima::fastcdr::exception::Exception& /*exception*/)
             {

--- a/fastdds_python/test/types/test_modulesPubSubTypes.hpp
+++ b/fastdds_python/test/types/test_modulesPubSubTypes.hpp
@@ -123,8 +123,6 @@ namespace eprosima
 
         };
 
-
-
         /*!
          * @brief This class represents the TopicDataType of the type CompleteTestType defined by the user in the IDL file.
          * @ingroup test_modules

--- a/fastdds_python/test/types/test_modulesTypeObjectSupport.hpp
+++ b/fastdds_python/test/types/test_modulesTypeObjectSupport.hpp
@@ -78,8 +78,6 @@ eProsima_user_DllExport void register_Material_type_identifier(
 eProsima_user_DllExport void register_StructType_type_identifier(
         eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
 
-
-
 /**
  * @brief Register CompleteTestType related TypeIdentifier.
  *        Fully-descriptive TypeIdentifiers are directly registered.

--- a/fastdds_python_examples/HelloWorldExample/HelloWorld.i
+++ b/fastdds_python_examples/HelloWorldExample/HelloWorld.i
@@ -54,7 +54,7 @@
 %}
 
 %include <fastcdr/config.h>
-%import(module="fastdds") "fastcdr/xcdr/optional.hpp"
+%import(module="fastdds") "fastcdr/cdr/fixed_size_string.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableTypedCollection.hpp"
 %import(module="fastdds") "fastdds/dds/core/LoanableSequence.hpp"

--- a/fastdds_python_examples/HelloWorldExample/HelloWorldPubSubTypes.cxx
+++ b/fastdds_python_examples/HelloWorldExample/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR updates types with Fast DDS Gen 4.0.4 in 2.1.x

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.1.x 2.0.x 1.4.x 1.2.x 1.0.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
