### PR TITLE
[23325] Add generic interfaces for RPC servers

### DIFF
--- a/fastdds_python/src/swig/fastdds/dds/rpc/interfaces.i
+++ b/fastdds_python/src/swig/fastdds/dds/rpc/interfaces.i
@@ -16,4 +16,11 @@
 #include "fastdds/dds/rpc/interfaces.hpp"
 %}
 
+%include "std_shared_ptr.i"
+
+%shared_ptr(eprosima::fastdds::dds::rpc::RpcServer);
+%ignore eprosima::fastdds::dds::rpc::RpcServer::execute_request;
+
+%include "fastdds/dds/rpc/interfaces/RpcRequest.hpp"
+%include "fastdds/dds/rpc/interfaces/RpcServer.hpp"
 %include "fastdds/dds/rpc/interfaces/RpcStatusCode.hpp"

--- a/fastdds_python_examples/RPCExample/generated_code/calculator.i
+++ b/fastdds_python_examples/RPCExample/generated_code/calculator.i
@@ -29,6 +29,13 @@
 
 // If using windows in debug, it would try to use python_d, which would not be found.
 %begin %{
+/*
+ * From: https://github.com/swig/swig/issues/2638
+ * When a module uses a type in a module that is defined in a different module,
+ * a false positive memory leak is detected.
+ * The following line silences this warning.
+ */
+#define SWIG_PYTHON_SILENT_MEMLEAK
 #ifdef _MSC_VER
 #define SWIG_PYTHON_INTERPRETER_NO_DEBUG
 #endif
@@ -74,6 +81,7 @@
 
 %import(module="fastdds") "fastdds/dds/rpc/exceptions/RpcException.hpp"
 %import(module="fastdds") "fastdds/dds/rpc/exceptions/RpcOperationError.hpp"
+%import(module="fastdds") "fastdds/dds/rpc/interfaces/RpcServer.hpp"
 
 %exception {
     try
@@ -228,17 +236,6 @@ namespace swig {
 
 
 %shared_ptr(calculator_base::BasicCalculator);
-%shared_ptr(calculator_base::BasicCalculatorServer);
-%extend calculator_base::BasicCalculatorServer
-{
-    void run()
-    {
-        Py_BEGIN_ALLOW_THREADS
-        self->run();
-        Py_END_ALLOW_THREADS
-    }
-}
-
 %shared_ptr(calculator_base::BasicCalculatorServer_IServerImplementation);
 %shared_ptr(calculator_base::BasicCalculatorServerImplementation);
 %feature("director") calculator_base::BasicCalculatorServerImplementation;
@@ -246,17 +243,6 @@ namespace swig {
 
 
 %shared_ptr(Calculator);
-%shared_ptr(CalculatorServer);
-%extend CalculatorServer
-{
-    void run()
-    {
-        Py_BEGIN_ALLOW_THREADS
-        self->run();
-        Py_END_ALLOW_THREADS
-    }
-}
-
 %shared_ptr(CalculatorServer_IServerImplementation);
 %shared_ptr(CalculatorServerImplementation);
 %feature("director") CalculatorServerImplementation;

--- a/fastdds_python_examples/RPCExample/generated_code/calculatorClient.cxx
+++ b/fastdds_python_examples/RPCExample/generated_code/calculatorClient.cxx
@@ -205,6 +205,7 @@ private:
             std::shared_ptr<T> result,
             std::promise<TResult>& promise)
     {
+        result->info.related_sample_identity.writer_guid(requester_->get_requester_reader()->guid());
         if (fdds::RETCODE_OK == requester_->send_request((void*)&request, result->info))
         {
             std::lock_guard<std::mutex> _ (mtx_);
@@ -224,6 +225,7 @@ private:
             const RequestType& request,
             std::shared_ptr<T> result)
     {
+        result->info.related_sample_identity.writer_guid(requester_->get_requester_reader()->guid());
         if (fdds::RETCODE_OK == requester_->send_request((void*)&request, result->info))
         {
             std::lock_guard<std::mutex> _ (mtx_);
@@ -719,6 +721,7 @@ private:
             std::shared_ptr<T> result,
             std::promise<TResult>& promise)
     {
+        result->info.related_sample_identity.writer_guid(requester_->get_requester_reader()->guid());
         if (fdds::RETCODE_OK == requester_->send_request((void*)&request, result->info))
         {
             std::lock_guard<std::mutex> _ (mtx_);
@@ -738,6 +741,7 @@ private:
             const RequestType& request,
             std::shared_ptr<T> result)
     {
+        result->info.related_sample_identity.writer_guid(requester_->get_requester_reader()->guid());
         if (fdds::RETCODE_OK == requester_->send_request((void*)&request, result->info))
         {
             std::lock_guard<std::mutex> _ (mtx_);

--- a/fastdds_python_examples/RPCExample/generated_code/calculatorServer.cxx
+++ b/fastdds_python_examples/RPCExample/generated_code/calculatorServer.cxx
@@ -63,7 +63,8 @@ namespace frpc = eprosima::fastdds::dds::rpc;
 namespace frtps = eprosima::fastdds::rtps;
 
 class BasicCalculatorServerLogic
-    : public BasicCalculatorServer
+    : public frpc::RpcServer
+    , public std::enable_shared_from_this<BasicCalculatorServerLogic>
 {
     using RequestType = BasicCalculator_Request;
     using ReplyType = BasicCalculator_Reply;
@@ -71,14 +72,29 @@ class BasicCalculatorServerLogic
 public:
 
     BasicCalculatorServerLogic(
-            eprosima::fastdds::dds::DomainParticipant& part,
+            fdds::DomainParticipant& part,
             const char* service_name,
-            const eprosima::fastdds::dds::ReplierQos& qos,
+            const fdds::ReplierQos& qos,
             size_t thread_pool_size,
             std::shared_ptr<BasicCalculatorServer_IServerImplementation> implementation)
-        : BasicCalculatorServer()
+        : BasicCalculatorServerLogic(
+                part,
+                service_name,
+                qos,
+                std::make_shared<ThreadPool>(*this, thread_pool_size),
+                std::move(implementation))
+    {
+    }
+
+    BasicCalculatorServerLogic(
+            fdds::DomainParticipant& part,
+            const char* service_name,
+            const fdds::ReplierQos& qos,
+            std::shared_ptr<frpc::RpcServerSchedulingStrategy> scheduler,
+            std::shared_ptr<BasicCalculatorServer_IServerImplementation> implementation)
+        : frpc::RpcServer()
         , participant_(part)
-        , thread_pool_(*this, thread_pool_size)
+        , request_scheduler_(scheduler)
         , implementation_(std::move(implementation))
     {
         // Register the service type support
@@ -106,8 +122,6 @@ public:
 
     ~BasicCalculatorServerLogic() override
     {
-        stop();
-
         if (nullptr != replier_)
         {
             participant_.delete_service_replier(service_->get_service_name(), replier_);
@@ -174,7 +188,21 @@ public:
         }
 
         // Wait for all threads to finish
-        thread_pool_.stop();
+        request_scheduler_->server_stopped(shared_from_this());
+    }
+
+    void execute_request(
+            const std::shared_ptr<frpc::RpcRequest>& request) override
+    {
+        auto ctx = std::dynamic_pointer_cast<RequestContext>(request);
+        if (ctx)
+        {
+            execute_request(ctx);
+        }
+        else
+        {
+            throw std::runtime_error("Invalid request context type");
+        }
     }
 
 private:
@@ -213,7 +241,7 @@ private:
 
     //} operation representation_limits
 
-    struct RequestContext : BasicCalculatorServer_ClientContext
+    struct RequestContext : frpc::RpcRequest
     {
         RequestType request;
         frpc::RequestInfo info;
@@ -375,6 +403,7 @@ private:
     };
 
     struct ThreadPool
+        : public frpc::RpcServerSchedulingStrategy
     {
         ThreadPool(
                 BasicCalculatorServerLogic& server,
@@ -391,7 +420,7 @@ private:
                     {
                         while (!finished_)
                         {
-                            std::shared_ptr<RequestContext> req;
+                            std::shared_ptr<frpc::RpcRequest> req;
                             {
                                 std::unique_lock<std::mutex> lock(mtx_);
                                 cv_.wait(lock, [this]()
@@ -417,9 +446,12 @@ private:
             }
         }
 
-        void new_request(
-                const std::shared_ptr<RequestContext>& req)
+        void schedule_request(
+                const std::shared_ptr<frpc::RpcRequest>& req,
+                const std::shared_ptr<frpc::RpcServer>& server) override
         {
+            static_cast<void>(server);
+
             std::lock_guard<std::mutex> lock(mtx_);
             if (!finished_)
             {
@@ -428,8 +460,11 @@ private:
             }
         }
 
-        void stop()
+        void server_stopped(
+                const std::shared_ptr<frpc::RpcServer>& server) override
         {
+            static_cast<void>(server);
+
             // Notify all threads in the pool to stop
             {
                 std::lock_guard<std::mutex> lock(mtx_);
@@ -451,7 +486,7 @@ private:
         BasicCalculatorServerLogic& server_;
         std::mutex mtx_;
         std::condition_variable cv_;
-        std::queue<std::shared_ptr<RequestContext>> requests_;
+        std::queue<std::shared_ptr<frpc::RpcRequest>> requests_;
         bool finished_{ false };
         std::vector<std::thread> threads_;
     };
@@ -483,7 +518,7 @@ private:
             processing_requests_[id] = ctx;
         }
 
-        thread_pool_.new_request(ctx);
+        request_scheduler_->schedule_request(ctx, shared_from_this());
     }
 
     void execute_request(
@@ -576,22 +611,73 @@ private:
     fdds::GuardCondition finish_condition_;
     std::mutex mtx_;
     std::map<frtps::SampleIdentity, std::shared_ptr<RequestContext>> processing_requests_;
-    ThreadPool thread_pool_;
+    std::shared_ptr<frpc::RpcServerSchedulingStrategy> request_scheduler_;
     std::shared_ptr<BasicCalculatorServer_IServerImplementation> implementation_;
 
 };
 
+struct BasicCalculatorServerProxy
+    : public frpc::RpcServer
+{
+    BasicCalculatorServerProxy(
+            std::shared_ptr<frpc::RpcServer> impl)
+        : impl_(std::move(impl))
+    {
+    }
+
+    ~BasicCalculatorServerProxy() override
+    {
+        if (impl_)
+        {
+            impl_->stop();
+        }
+    }
+
+    void run() override
+    {
+        impl_->run();
+    }
+
+    void stop() override
+    {
+        impl_->stop();
+    }
+
+    void execute_request(
+            const std::shared_ptr<frpc::RpcRequest>& request) override
+    {
+        impl_->execute_request(request);
+    }
+
+private:
+
+   std::shared_ptr<frpc::RpcServer> impl_;
+};
+
 }  // namespace detail
 
-std::shared_ptr<BasicCalculatorServer> create_BasicCalculatorServer(
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcServer> create_BasicCalculatorServer(
         eprosima::fastdds::dds::DomainParticipant& part,
         const char* service_name,
         const eprosima::fastdds::dds::ReplierQos& qos,
         size_t thread_pool_size,
         std::shared_ptr<BasicCalculatorServer_IServerImplementation> implementation)
 {
-    return std::make_shared<detail::BasicCalculatorServerLogic>(
+    auto ptr = std::make_shared<detail::BasicCalculatorServerLogic>(
         part, service_name, qos, thread_pool_size, implementation);
+    return std::make_shared<detail::BasicCalculatorServerProxy>(ptr);
+}
+
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcServer> create_BasicCalculatorServer(
+        eprosima::fastdds::dds::DomainParticipant& part,
+        const char* service_name,
+        const eprosima::fastdds::dds::ReplierQos& qos,
+        std::shared_ptr<eprosima::fastdds::dds::rpc::RpcServerSchedulingStrategy> scheduler,
+        std::shared_ptr<BasicCalculatorServer_IServerImplementation> implementation)
+{
+    auto ptr = std::make_shared<detail::BasicCalculatorServerLogic>(
+        part, service_name, qos, scheduler, implementation);
+    return std::make_shared<detail::BasicCalculatorServerProxy>(ptr);
 }
 
 //} interface BasicCalculator
@@ -608,7 +694,8 @@ namespace frpc = eprosima::fastdds::dds::rpc;
 namespace frtps = eprosima::fastdds::rtps;
 
 class CalculatorServerLogic
-    : public CalculatorServer
+    : public frpc::RpcServer
+    , public std::enable_shared_from_this<CalculatorServerLogic>
 {
     using RequestType = Calculator_Request;
     using ReplyType = Calculator_Reply;
@@ -616,14 +703,29 @@ class CalculatorServerLogic
 public:
 
     CalculatorServerLogic(
-            eprosima::fastdds::dds::DomainParticipant& part,
+            fdds::DomainParticipant& part,
             const char* service_name,
-            const eprosima::fastdds::dds::ReplierQos& qos,
+            const fdds::ReplierQos& qos,
             size_t thread_pool_size,
             std::shared_ptr<CalculatorServer_IServerImplementation> implementation)
-        : CalculatorServer()
+        : CalculatorServerLogic(
+                part,
+                service_name,
+                qos,
+                std::make_shared<ThreadPool>(*this, thread_pool_size),
+                std::move(implementation))
+    {
+    }
+
+    CalculatorServerLogic(
+            fdds::DomainParticipant& part,
+            const char* service_name,
+            const fdds::ReplierQos& qos,
+            std::shared_ptr<frpc::RpcServerSchedulingStrategy> scheduler,
+            std::shared_ptr<CalculatorServer_IServerImplementation> implementation)
+        : frpc::RpcServer()
         , participant_(part)
-        , thread_pool_(*this, thread_pool_size)
+        , request_scheduler_(scheduler)
         , implementation_(std::move(implementation))
     {
         // Register the service type support
@@ -651,8 +753,6 @@ public:
 
     ~CalculatorServerLogic() override
     {
-        stop();
-
         if (nullptr != replier_)
         {
             participant_.delete_service_replier(service_->get_service_name(), replier_);
@@ -719,7 +819,21 @@ public:
         }
 
         // Wait for all threads to finish
-        thread_pool_.stop();
+        request_scheduler_->server_stopped(shared_from_this());
+    }
+
+    void execute_request(
+            const std::shared_ptr<frpc::RpcRequest>& request) override
+    {
+        auto ctx = std::dynamic_pointer_cast<RequestContext>(request);
+        if (ctx)
+        {
+            execute_request(ctx);
+        }
+        else
+        {
+            throw std::runtime_error("Invalid request context type");
+        }
     }
 
 private:
@@ -1100,7 +1214,7 @@ private:
 
     //} operation accumulator
 
-    struct RequestContext : CalculatorServer_ClientContext
+    struct RequestContext : frpc::RpcRequest
     {
         RequestType request;
         frpc::RequestInfo info;
@@ -1348,6 +1462,7 @@ private:
     };
 
     struct ThreadPool
+        : public frpc::RpcServerSchedulingStrategy
     {
         ThreadPool(
                 CalculatorServerLogic& server,
@@ -1364,7 +1479,7 @@ private:
                     {
                         while (!finished_)
                         {
-                            std::shared_ptr<RequestContext> req;
+                            std::shared_ptr<frpc::RpcRequest> req;
                             {
                                 std::unique_lock<std::mutex> lock(mtx_);
                                 cv_.wait(lock, [this]()
@@ -1390,9 +1505,12 @@ private:
             }
         }
 
-        void new_request(
-                const std::shared_ptr<RequestContext>& req)
+        void schedule_request(
+                const std::shared_ptr<frpc::RpcRequest>& req,
+                const std::shared_ptr<frpc::RpcServer>& server) override
         {
+            static_cast<void>(server);
+
             std::lock_guard<std::mutex> lock(mtx_);
             if (!finished_)
             {
@@ -1401,8 +1519,11 @@ private:
             }
         }
 
-        void stop()
+        void server_stopped(
+                const std::shared_ptr<frpc::RpcServer>& server) override
         {
+            static_cast<void>(server);
+
             // Notify all threads in the pool to stop
             {
                 std::lock_guard<std::mutex> lock(mtx_);
@@ -1424,7 +1545,7 @@ private:
         CalculatorServerLogic& server_;
         std::mutex mtx_;
         std::condition_variable cv_;
-        std::queue<std::shared_ptr<RequestContext>> requests_;
+        std::queue<std::shared_ptr<frpc::RpcRequest>> requests_;
         bool finished_{ false };
         std::vector<std::thread> threads_;
     };
@@ -1456,7 +1577,7 @@ private:
             processing_requests_[id] = ctx;
         }
 
-        thread_pool_.new_request(ctx);
+        request_scheduler_->schedule_request(ctx, shared_from_this());
     }
 
     void execute_request(
@@ -1635,22 +1756,73 @@ private:
     fdds::GuardCondition finish_condition_;
     std::mutex mtx_;
     std::map<frtps::SampleIdentity, std::shared_ptr<RequestContext>> processing_requests_;
-    ThreadPool thread_pool_;
+    std::shared_ptr<frpc::RpcServerSchedulingStrategy> request_scheduler_;
     std::shared_ptr<CalculatorServer_IServerImplementation> implementation_;
 
 };
 
+struct CalculatorServerProxy
+    : public frpc::RpcServer
+{
+    CalculatorServerProxy(
+            std::shared_ptr<frpc::RpcServer> impl)
+        : impl_(std::move(impl))
+    {
+    }
+
+    ~CalculatorServerProxy() override
+    {
+        if (impl_)
+        {
+            impl_->stop();
+        }
+    }
+
+    void run() override
+    {
+        impl_->run();
+    }
+
+    void stop() override
+    {
+        impl_->stop();
+    }
+
+    void execute_request(
+            const std::shared_ptr<frpc::RpcRequest>& request) override
+    {
+        impl_->execute_request(request);
+    }
+
+private:
+
+   std::shared_ptr<frpc::RpcServer> impl_;
+};
+
 }  // namespace detail
 
-std::shared_ptr<CalculatorServer> create_CalculatorServer(
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcServer> create_CalculatorServer(
         eprosima::fastdds::dds::DomainParticipant& part,
         const char* service_name,
         const eprosima::fastdds::dds::ReplierQos& qos,
         size_t thread_pool_size,
         std::shared_ptr<CalculatorServer_IServerImplementation> implementation)
 {
-    return std::make_shared<detail::CalculatorServerLogic>(
+    auto ptr = std::make_shared<detail::CalculatorServerLogic>(
         part, service_name, qos, thread_pool_size, implementation);
+    return std::make_shared<detail::CalculatorServerProxy>(ptr);
+}
+
+std::shared_ptr<eprosima::fastdds::dds::rpc::RpcServer> create_CalculatorServer(
+        eprosima::fastdds::dds::DomainParticipant& part,
+        const char* service_name,
+        const eprosima::fastdds::dds::ReplierQos& qos,
+        std::shared_ptr<eprosima::fastdds::dds::rpc::RpcServerSchedulingStrategy> scheduler,
+        std::shared_ptr<CalculatorServer_IServerImplementation> implementation)
+{
+    auto ptr = std::make_shared<detail::CalculatorServerLogic>(
+        part, service_name, qos, scheduler, implementation);
+    return std::make_shared<detail::CalculatorServerProxy>(ptr);
 }
 
 //} interface Calculator

--- a/fastdds_python_examples/RPCExample/generated_code/calculatorServer.hpp
+++ b/fastdds_python_examples/RPCExample/generated_code/calculatorServer.hpp
@@ -35,195 +35,139 @@
 
 namespace calculator_base {
 
-/**
- * @brief Context for a client request.
- */
-struct BasicCalculatorServer_ClientContext
-{
-    virtual ~BasicCalculatorServer_ClientContext() = default;
-
-    /**
-     * @brief Get the GUID of the client that made the request.
-     *
-     * @return The GUID of the client that made the request.
-     */
-    virtual const eprosima::fastdds::rtps::GUID_t& get_client_id() const = 0;
-
-    /**
-     * @brief Get the locators of the client that made the request.
-     *
-     * @return The locators of the client that made the request.
-     */
-    virtual const eprosima::fastdds::rtps::RemoteLocatorList& get_client_locators() const = 0;
-};
-
 struct BasicCalculatorServer_IServerImplementation
 {
     virtual ~BasicCalculatorServer_IServerImplementation() = default;
 
     virtual int32_t addition(
-            const BasicCalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ int32_t value1,
             /*in*/ int32_t value2) = 0;
 
 
 
     virtual int32_t subtraction(
-            const BasicCalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ int32_t value1,
             /*in*/ int32_t value2) = 0;
 
 
 
     virtual calculator_base::detail::BasicCalculator_representation_limits_Out representation_limits(
-            const BasicCalculatorServer_ClientContext& info) = 0;
-
-};
-
-struct BasicCalculatorServer
-{
-    virtual ~BasicCalculatorServer() = default;
-
-    /**
-     * @brief Run the server.
-     *
-     * This method starts the server and begins processing requests.
-     * The method will block until the server is stopped.
-     */
-    virtual void run() = 0;
-
-    /**
-     * @brief Stop the server.
-     *
-     * This method stops the server and releases all resources.
-     * It will cancel all pending requests, and wait for all processing threads to finish before returning.
-     */
-    virtual void stop() = 0;
+            const eprosima::fastdds::dds::rpc::RpcRequest& info) = 0;
 
 };
 
 /**
- * @brief Create a BasicCalculatorServer instance.
+ * @brief Create a BasicCalculator server instance.
  *
  * @param part             The DomainParticipant to use for the server.
  * @param service_name     The name of the service.
  * @param qos              The QoS settings for the server.
  * @param thread_pool_size The size of the thread pool to use for processing requests.
- *                         When set to 0, a new thread will be created when no threads are available.
+ *                         When set to 0, a pool with a single thread will be created.
  * @param implementation   The implementation of the server interface.
  */
-extern eProsima_user_DllExport std::shared_ptr<BasicCalculatorServer> create_BasicCalculatorServer(
+extern eProsima_user_DllExport std::shared_ptr<eprosima::fastdds::dds::rpc::RpcServer> create_BasicCalculatorServer(
         eprosima::fastdds::dds::DomainParticipant& part,
         const char* service_name,
         const eprosima::fastdds::dds::ReplierQos& qos,
         size_t thread_pool_size,
         std::shared_ptr<BasicCalculatorServer_IServerImplementation> implementation);
 
+/**
+ * @brief Create a BasicCalculator server instance.
+ *
+ * @param part            The DomainParticipant to use for the server.
+ * @param service_name    The name of the service.
+ * @param qos             The QoS settings for the server.
+ * @param scheduler       The request scheduling strategy to use for the server.
+ * @param implementation  The implementation of the server interface.
+ */
+extern eProsima_user_DllExport std::shared_ptr<eprosima::fastdds::dds::rpc::RpcServer> create_BasicCalculatorServer(
+        eprosima::fastdds::dds::DomainParticipant& part,
+        const char* service_name,
+        const eprosima::fastdds::dds::ReplierQos& qos,
+        std::shared_ptr<eprosima::fastdds::dds::rpc::RpcServerSchedulingStrategy> scheduler,
+        std::shared_ptr<BasicCalculatorServer_IServerImplementation> implementation);
+
 
 } // namespace calculator_base
-
-/**
- * @brief Context for a client request.
- */
-struct CalculatorServer_ClientContext
-{
-    virtual ~CalculatorServer_ClientContext() = default;
-
-    /**
-     * @brief Get the GUID of the client that made the request.
-     *
-     * @return The GUID of the client that made the request.
-     */
-    virtual const eprosima::fastdds::rtps::GUID_t& get_client_id() const = 0;
-
-    /**
-     * @brief Get the locators of the client that made the request.
-     *
-     * @return The locators of the client that made the request.
-     */
-    virtual const eprosima::fastdds::rtps::RemoteLocatorList& get_client_locators() const = 0;
-};
 
 struct CalculatorServer_IServerImplementation
 {
     virtual ~CalculatorServer_IServerImplementation() = default;
 
     virtual int32_t addition(
-            const CalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ int32_t value1,
             /*in*/ int32_t value2) = 0;
 
 
 
     virtual int32_t subtraction(
-            const CalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ int32_t value1,
             /*in*/ int32_t value2) = 0;
 
 
 
     virtual calculator_base::detail::BasicCalculator_representation_limits_Out representation_limits(
-            const CalculatorServer_ClientContext& info) = 0;
+            const eprosima::fastdds::dds::rpc::RpcRequest& info) = 0;
 
 
 
     virtual void fibonacci_seq(
-            const CalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ uint32_t n_results,
             /*result*/ eprosima::fastdds::dds::rpc::RpcServerWriter<int32_t>& result_writer) = 0;
 
 
 
     virtual int32_t sum_all(
-            const CalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ eprosima::fastdds::dds::rpc::RpcServerReader<int32_t>& value) = 0;
 
 
 
     virtual void accumulator(
-            const CalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ eprosima::fastdds::dds::rpc::RpcServerReader<int32_t>& value,
             /*result*/ eprosima::fastdds::dds::rpc::RpcServerWriter<int32_t>& result_writer) = 0;
 
 };
 
-struct CalculatorServer
-{
-    virtual ~CalculatorServer() = default;
-
-    /**
-     * @brief Run the server.
-     *
-     * This method starts the server and begins processing requests.
-     * The method will block until the server is stopped.
-     */
-    virtual void run() = 0;
-
-    /**
-     * @brief Stop the server.
-     *
-     * This method stops the server and releases all resources.
-     * It will cancel all pending requests, and wait for all processing threads to finish before returning.
-     */
-    virtual void stop() = 0;
-
-};
-
 /**
- * @brief Create a CalculatorServer instance.
+ * @brief Create a Calculator server instance.
  *
  * @param part             The DomainParticipant to use for the server.
  * @param service_name     The name of the service.
  * @param qos              The QoS settings for the server.
  * @param thread_pool_size The size of the thread pool to use for processing requests.
- *                         When set to 0, a new thread will be created when no threads are available.
+ *                         When set to 0, a pool with a single thread will be created.
  * @param implementation   The implementation of the server interface.
  */
-extern eProsima_user_DllExport std::shared_ptr<CalculatorServer> create_CalculatorServer(
+extern eProsima_user_DllExport std::shared_ptr<eprosima::fastdds::dds::rpc::RpcServer> create_CalculatorServer(
         eprosima::fastdds::dds::DomainParticipant& part,
         const char* service_name,
         const eprosima::fastdds::dds::ReplierQos& qos,
         size_t thread_pool_size,
+        std::shared_ptr<CalculatorServer_IServerImplementation> implementation);
+
+/**
+ * @brief Create a Calculator server instance.
+ *
+ * @param part            The DomainParticipant to use for the server.
+ * @param service_name    The name of the service.
+ * @param qos             The QoS settings for the server.
+ * @param scheduler       The request scheduling strategy to use for the server.
+ * @param implementation  The implementation of the server interface.
+ */
+extern eProsima_user_DllExport std::shared_ptr<eprosima::fastdds::dds::rpc::RpcServer> create_CalculatorServer(
+        eprosima::fastdds::dds::DomainParticipant& part,
+        const char* service_name,
+        const eprosima::fastdds::dds::ReplierQos& qos,
+        std::shared_ptr<eprosima::fastdds::dds::rpc::RpcServerSchedulingStrategy> scheduler,
         std::shared_ptr<CalculatorServer_IServerImplementation> implementation);
 
 

--- a/fastdds_python_examples/RPCExample/generated_code/calculatorServerImpl.hpp
+++ b/fastdds_python_examples/RPCExample/generated_code/calculatorServerImpl.hpp
@@ -34,7 +34,7 @@ struct BasicCalculatorServerImplementation :
 {
 
     int32_t addition(
-            const BasicCalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ int32_t value1,
             /*in*/ int32_t value2) override
     {
@@ -45,7 +45,7 @@ struct BasicCalculatorServerImplementation :
     }
 
     int32_t subtraction(
-            const BasicCalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ int32_t value1,
             /*in*/ int32_t value2) override
     {
@@ -56,7 +56,7 @@ struct BasicCalculatorServerImplementation :
     }
 
     calculator_base::detail::BasicCalculator_representation_limits_Out representation_limits(
-            const BasicCalculatorServer_ClientContext& info) override
+            const eprosima::fastdds::dds::rpc::RpcRequest& info) override
     {
         static_cast<void>(info);
         throw eprosima::fastdds::dds::rpc::RemoteUnsupportedError("Operation 'representation_limits' is not implemented");
@@ -76,7 +76,7 @@ struct CalculatorServerImplementation :
 {
 
     int32_t addition(
-            const CalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ int32_t value1,
             /*in*/ int32_t value2) override
     {
@@ -87,7 +87,7 @@ struct CalculatorServerImplementation :
     }
 
     int32_t subtraction(
-            const CalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ int32_t value1,
             /*in*/ int32_t value2) override
     {
@@ -98,14 +98,14 @@ struct CalculatorServerImplementation :
     }
 
     calculator_base::detail::BasicCalculator_representation_limits_Out representation_limits(
-            const CalculatorServer_ClientContext& info) override
+            const eprosima::fastdds::dds::rpc::RpcRequest& info) override
     {
         static_cast<void>(info);
         throw eprosima::fastdds::dds::rpc::RemoteUnsupportedError("Operation 'representation_limits' is not implemented");
     }
 
     void fibonacci_seq(
-            const CalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ uint32_t n_results,
             /*result*/ eprosima::fastdds::dds::rpc::RpcServerWriter<int32_t>& result_writer) override
     {
@@ -116,7 +116,7 @@ struct CalculatorServerImplementation :
     }
 
     int32_t sum_all(
-            const CalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ eprosima::fastdds::dds::rpc::RpcServerReader<int32_t>& value) override
     {
         static_cast<void>(info);
@@ -125,7 +125,7 @@ struct CalculatorServerImplementation :
     }
 
     void accumulator(
-            const CalculatorServer_ClientContext& info,
+            const eprosima::fastdds::dds::rpc::RpcRequest& info,
             /*in*/ eprosima::fastdds::dds::rpc::RpcServerReader<int32_t>& value,
             /*result*/ eprosima::fastdds::dds::rpc::RpcServerWriter<int32_t>& result_writer) override
     {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Expose the server and request interfaces from https://github.com/eProsima/Fast-DDS/pull/5873

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.2.x 1.4.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
