### PR TITLE
[23573] Add OriginalWriterInfo to Fast DDS Python

### DIFF
--- a/fastdds_python/src/swig/fastdds.i
+++ b/fastdds_python/src/swig/fastdds.i
@@ -166,6 +166,7 @@ namespace xtypes {
 %include "fastdds/rtps/common/RemoteLocators.i"
 %include "fastdds/rtps/common/SequenceNumber.i"
 %include "fastdds/rtps/common/SampleIdentity.i"
+%include "fastdds/rtps/common/OriginalWriterInfo.i"
 %include "fastdds/rtps/common/WriteParams.i"
 %include "fastdds/rtps/builtin/data/ContentFilterProperty.i"
 %include "fastdds/rtps/reader/ReaderDiscoveryInfo.i"

--- a/fastdds_python/src/swig/fastdds/dds/core/policy/ParameterTypes.i
+++ b/fastdds_python/src/swig/fastdds/dds/core/policy/ParameterTypes.i
@@ -22,6 +22,8 @@
 // Ignore unimplemented method (the wrapper will try to use it)
 %ignore eprosima::fastdds::dds::ParameterSampleIdentity_t::addToCDRMessage;
 %ignore eprosima::fastdds::dds::ParameterSampleIdentity_t::readFromCDRMessage;
+%ignore eprosima::fastdds::dds::ParameterOriginalWriterInfo_t::addToCDRMessage;
+%ignore eprosima::fastdds::dds::ParameterOriginalWriterInfo_t::readFromCDRMessage;
 
 // The class ParameterPropertyList_t::iterator does not have default constructor
 // This tells SWIG it must wrap the constructors or the compilation will fail

--- a/fastdds_python/src/swig/fastdds/rtps/common/OriginalWriterInfo.i
+++ b/fastdds_python/src/swig/fastdds/rtps/common/OriginalWriterInfo.i
@@ -1,4 +1,4 @@
-// Copyright 2022 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 %{
-#include "fastdds/rtps/common/WriteParams.hpp"
+#include "fastdds/rtps/common/OriginalWriterInfo.hpp"
 %}
 
 // Ignore overloaded constructor and methods that have no effect on target language
-%ignore eprosima::fastdds::rtps::WriteParams::WriteParams(WriteParams &&);
-%ignore eprosima::fastdds::rtps::WriteParams::sample_identity(SampleIdentity &&);
-%ignore eprosima::fastdds::rtps::WriteParams::related_sample_identity(SampleIdentity &&);
-%ignore eprosima::fastdds::rtps::WriteParams::original_writer_info(OriginalWriterInfo &&);
+%ignore eprosima::fastdds::rtps::OriginalWriterInfo::OriginalWriterInfo(OriginalWriterInfo &&);
+%ignore eprosima::fastdds::rtps::OriginalWriterInfo::original_writer_guid(GUID_t &&);
+%ignore eprosima::fastdds::rtps::OriginalWriterInfo::original_writer_guid() const;
+%ignore eprosima::fastdds::rtps::OriginalWriterInfo::sequence_number(SequenceNumber_t &&);
+%ignore eprosima::fastdds::rtps::OriginalWriterInfo::sequence_number(SequenceNumber_t) const;
 
-%include "fastdds/rtps/common/WriteParams.hpp"
+%include "fastdds/rtps/common/OriginalWriterInfo.hpp"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
This PR updates the repo to make it compatible with the new field OriginalWriterInfo introduced in:

- https://github.com/eProsima/Fast-DDS/pull/5975

And must be merged after it

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.3.x 2.2.x 1.4.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
