### PR TITLE
[24377] Set Fast DDS version 3.5 as EOL

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@
     In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
     Please uncomment following line, adjusting the corresponding target branches for the backport.
 -->
-<!-- @Mergifyio backport 2.5.x 2.4.x 2.2.x 1.4.x -->
+<!-- @Mergifyio backport 2.4.x 2.2.x 1.4.x -->
 
 <!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
 <!-- Fixes #(issue) -->

--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -9,6 +9,7 @@ Please, refer to the [main branch](https://github.com/eProsima/Fast-DDS-Python/b
 
 |Fast DDS Version|Fast DDS Python Version|Fast DDS Python Version branch|Fast DDS Python Latest Release|
 |----------------|-----------------------|------------------------------|------------------------------|
+|3.6|2.6|[2.6.x](https://github.com/eProsima/Fast-DDS-Python/tree/2.6.x)|[v2.6.1](https://github.com/eProsima/Fast-DDS-Python/releases/tag/v2.6.1)|
 |3.4|2.4|[2.4.x](https://github.com/eProsima/Fast-DDS-Python/tree/2.4.x)|[v2.4.1](https://github.com/eProsima/Fast-DDS-Python/releases/tag/v2.4.1)|
 |3.2|2.2|[2.2.x](https://github.com/eProsima/Fast-DDS-Python/tree/2.2.x)|[v2.2.1](https://github.com/eProsima/Fast-DDS-Python/releases/tag/v2.2.1)|
 |2.14|1.4|[1.4.x](https://github.com/eProsima/Fast-DDS-Python/tree/1.4.x)|[v1.4.2](https://github.com/eProsima/Fast-DDS-Python/releases/tag/v1.4.2)|
@@ -19,6 +20,7 @@ Please, refer to the [main branch](https://github.com/eProsima/Fast-DDS-Python/b
 
 |Fast DDS Version|Fast DDS Python Version|Fast DDS Python Version branch|Fast DDS Python Latest Release|Release Date|EOL Date|
 |----------------|-----------------------|------------------------------|------------------------------|------------|--------|
+|3.5|2.5|[2.5.x](https://github.com/eProsima/Fast-DDS-Python/tree/2.5.x)|[v2.5.0](https://github.com/eProsima/Fast-DDS-Python/releases/tag/v2.5.0)| February 2026 | April 2026 |
 |3.3|2.3|[2.3.x](https://github.com/eProsima/Fast-DDS-Python/tree/2.3.x)|[v2.3.1](https://github.com/eProsima/Fast-DDS-Python/releases/tag/v2.3.1)| July 2025 | January 2025 |
 |3.1|2.1|[2.1.x](https://github.com/eProsima/Fast-DDS-Python/tree/2.1.x)|[v2.1.1](https://github.com/eProsima/Fast-DDS-Python/releases/tag/v2.1.1)| October 2024 | June 2025 |
 |3.0|2.0|[2.0.x](https://github.com/eProsima/Fast-DDS-Python/tree/2.0.x)|[v2.0.0](https://github.com/eProsima/Fast-DDS-Python/releases/tag/v2.0.0)|August 2024| February 2025|


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->


This PR does all the work necessary in the repo to mark version 3.5 as EOL.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.5.x 2.4.x 2.2.x 1.4.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: Check CI results: changes do not issue any warning.
- _N/A_: Check CI results: failing tests are unrelated with the changes.
