### PR TITLE
[23923] Ignore new RTPSParticipantAttributes

### DIFF
--- a/fastdds_python/src/swig/fastdds/rtps/attributes/RTPSParticipantAttributes.i
+++ b/fastdds_python/src/swig/fastdds/rtps/attributes/RTPSParticipantAttributes.i
@@ -20,6 +20,8 @@
 %ignore eprosima::fastdds::rtps::DiscoverySettings::setStaticEndpointXMLFilename;
 %ignore eprosima::fastdds::rtps::DiscoverySettings::getStaticEndpointXMLFilename;
 %ignore eprosima::fastdds::rtps::RTPSParticipantAttributes;
+%ignore eprosima::fastdds::rtps::RTPSParticipantConstantAttributes;
+%ignore eprosima::fastdds::rtps::RTPSParticipantMutableAttributes;
 %ignore eprosima::fastdds::rtps::operator <<(std::ostream&, const DiscoveryProtocol&);;
 
 %include "fastdds/rtps/attributes/RTPSParticipantAttributes.hpp"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
PR https://github.com/eProsima/Fast-DDS/pull/6370 introduces new RTPSParticipantAttributes class. This PR ignores them similarly to the original one.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.5.x 2.4.x 2.2.x 1.4.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] : Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
