### PR TITLE
[24490] Don't use infinite nanoseconds in API tests

### DIFF
--- a/fastdds_python/test/api/test_qos.py
+++ b/fastdds_python/test/api/test_qos.py
@@ -43,13 +43,11 @@ def test_datareader_qos():
     # .reliability
     datareader_qos.reliability().kind = fastdds.RELIABLE_RELIABILITY_QOS
     datareader_qos.reliability().max_blocking_time.seconds = 100
-    datareader_qos.reliability().max_blocking_time.nanosec = \
-        fastdds.Time_t.INFINITE_NANOSECONDS
+    datareader_qos.reliability().max_blocking_time.nanosec = 1
     assert(fastdds.RELIABLE_RELIABILITY_QOS ==
            datareader_qos.reliability().kind)
     assert(100 == datareader_qos.reliability().max_blocking_time.seconds)
-    assert(fastdds.Time_t.INFINITE_NANOSECONDS ==
-           datareader_qos.reliability().max_blocking_time.nanosec)
+    assert(1 == datareader_qos.reliability().max_blocking_time.nanosec)
 
     # .destination_order
     datareader_qos.destination_order().kind = \
@@ -317,8 +315,7 @@ def test_datareader_qos():
            default_datareader_qos.reliability().kind)
     assert(100 == default_datareader_qos.reliability().
            max_blocking_time.seconds)
-    assert(fastdds.Time_t.INFINITE_NANOSECONDS ==
-           default_datareader_qos.reliability().max_blocking_time.nanosec)
+    assert(1 == default_datareader_qos.reliability().max_blocking_time.nanosec)
 
     # .destination_order
     assert(fastdds.BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS ==
@@ -511,13 +508,11 @@ def test_datawriter_qos():
     # .reliability
     datawriter_qos.reliability().kind = fastdds.RELIABLE_RELIABILITY_QOS
     datawriter_qos.reliability().max_blocking_time.seconds = 100
-    datawriter_qos.reliability().max_blocking_time.nanosec = \
-        fastdds.Time_t.INFINITE_NANOSECONDS
+    datawriter_qos.reliability().max_blocking_time.nanosec = 1
     assert(fastdds.RELIABLE_RELIABILITY_QOS ==
            datawriter_qos.reliability().kind)
     assert(100 == datawriter_qos.reliability().max_blocking_time.seconds)
-    assert(fastdds.Time_t.INFINITE_NANOSECONDS ==
-           datawriter_qos.reliability().max_blocking_time.nanosec)
+    assert(1 == datawriter_qos.reliability().max_blocking_time.nanosec)
 
     # .destination_order
     datawriter_qos.destination_order().kind = \
@@ -751,8 +746,7 @@ def test_datawriter_qos():
            default_datawriter_qos.reliability().kind)
     assert(100 == default_datawriter_qos.reliability().
            max_blocking_time.seconds)
-    assert(fastdds.Time_t.INFINITE_NANOSECONDS ==
-           default_datawriter_qos.reliability().max_blocking_time.nanosec)
+    assert(1 == default_datawriter_qos.reliability().max_blocking_time.nanosec)
 
     # .destination_order
     assert(fastdds.BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS ==
@@ -928,12 +922,10 @@ def test_topic_qos():
     # .reliability
     topic_qos.reliability().kind = fastdds.RELIABLE_RELIABILITY_QOS
     topic_qos.reliability().max_blocking_time.seconds = 100
-    topic_qos.reliability().max_blocking_time.nanosec = \
-        fastdds.Time_t.INFINITE_NANOSECONDS
+    topic_qos.reliability().max_blocking_time.nanosec = 1
     assert(fastdds.RELIABLE_RELIABILITY_QOS == topic_qos.reliability().kind)
     assert(100 == topic_qos.reliability().max_blocking_time.seconds)
-    assert(fastdds.Time_t.INFINITE_NANOSECONDS ==
-           topic_qos.reliability().max_blocking_time.nanosec)
+    assert(1 == topic_qos.reliability().max_blocking_time.nanosec)
 
     # .destination_order
     topic_qos.destination_order().kind = \
@@ -1035,8 +1027,7 @@ def test_topic_qos():
     assert(fastdds.RELIABLE_RELIABILITY_QOS ==
            default_topic_qos.reliability().kind)
     assert(100 == default_topic_qos.reliability().max_blocking_time.seconds)
-    assert(fastdds.Time_t.INFINITE_NANOSECONDS ==
-           default_topic_qos.reliability().max_blocking_time.nanosec)
+    assert(1 == default_topic_qos.reliability().max_blocking_time.nanosec)
 
     # .destination_order
     assert(fastdds.BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS ==


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.4.x 2.2.x 1.4.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS Python developers must also refer to the internal Redmine task. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
