### PR TITLE
[24005] Bump version to 1.0.3

### DIFF
--- a/fastdds_python/CMakeLists.txt
+++ b/fastdds_python/CMakeLists.txt
@@ -24,7 +24,7 @@ if(POLICY CMP0086)
   cmake_policy(SET CMP0086 NEW)
 endif()
 
-project(fastdds_python VERSION 1.0.2)
+project(fastdds_python VERSION 1.0.3)
 
 ###############################################################################
 # Dependencies


### PR DESCRIPTION
This PR bumps the version to 1.0.3.
Generated automatically by the release tool.